### PR TITLE
feat(ui): lock typography + font-size slider + note-labels toggle + fretboard labels

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -12,126 +12,19 @@ html {
 body {
 	background: var(--color-bg-deep);
 	color: var(--color-text-primary);
-	font-family: var(--font-pixel);
+	font-family: var(--font-body);
 	margin: 0;
 	overflow: hidden;
-}
-
-/* Font mode classes on <body>. Each class remaps what .font-pixel means,
-   so every component that opted in to the pixel-font look follows the
-   active choice. Pixel fonts keep crunchy rendering; clean enables
-   antialiasing. */
-
-body.font-press-start,
-body.font-press-start .font-pixel,
-body.font-press-start .pixel-btn {
-	font-family: var(--font-press-start);
-	-webkit-font-smoothing: none;
-	-moz-osx-font-smoothing: unset;
-	text-rendering: optimizeSpeed;
-	letter-spacing: 0;
-}
-
-body.font-vt323,
-body.font-vt323 .font-pixel,
-body.font-vt323 .pixel-btn {
-	font-family: var(--font-vt323);
-	-webkit-font-smoothing: antialiased;
-	text-rendering: optimizeLegibility;
-	letter-spacing: 1px;
-}
-
-body.font-silkscreen,
-body.font-silkscreen .font-pixel,
-body.font-silkscreen .pixel-btn {
-	font-family: var(--font-silkscreen);
-	-webkit-font-smoothing: none;
-	text-rendering: optimizeSpeed;
-	letter-spacing: 0;
-}
-
-body.font-pixelify,
-body.font-pixelify .font-pixel,
-body.font-pixelify .pixel-btn {
-	font-family: var(--font-pixelify);
-	-webkit-font-smoothing: antialiased;
-	text-rendering: optimizeLegibility;
-	letter-spacing: 0;
-}
-
-body.font-dotgothic,
-body.font-dotgothic .font-pixel,
-body.font-dotgothic .pixel-btn {
-	font-family: var(--font-dotgothic);
-	-webkit-font-smoothing: none;
-	text-rendering: optimizeSpeed;
-	letter-spacing: 0;
-}
-
-body.font-jersey,
-body.font-jersey .font-pixel,
-body.font-jersey .pixel-btn {
-	font-family: var(--font-jersey);
-	-webkit-font-smoothing: antialiased;
-	text-rendering: optimizeLegibility;
-	letter-spacing: 0;
-}
-
-body.font-tiny5,
-body.font-tiny5 .font-pixel,
-body.font-tiny5 .pixel-btn {
-	font-family: var(--font-tiny5);
-	-webkit-font-smoothing: none;
-	text-rendering: optimizeSpeed;
-	letter-spacing: 0;
-}
-
-body.font-workbench,
-body.font-workbench .font-pixel,
-body.font-workbench .pixel-btn {
-	font-family: var(--font-workbench);
-	-webkit-font-smoothing: antialiased;
-	text-rendering: optimizeLegibility;
-	letter-spacing: 0;
-}
-
-body.font-jetbrains,
-body.font-jetbrains .font-pixel,
-body.font-jetbrains .pixel-btn {
-	font-family: var(--font-jetbrains);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-rendering: optimizeLegibility;
-	letter-spacing: 0;
 }
 
-body.font-fira,
-body.font-fira .font-pixel,
-body.font-fira .pixel-btn {
-	font-family: var(--font-fira);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	text-rendering: optimizeLegibility;
-	letter-spacing: 0;
-}
-
-body.font-plex,
-body.font-plex .font-pixel,
-body.font-plex .pixel-btn {
-	font-family: var(--font-plex);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	text-rendering: optimizeLegibility;
-	letter-spacing: 0;
-}
-
-body.font-clean,
-body.font-clean .font-pixel,
-body.font-clean .pixel-btn {
-	font-family: var(--font-reading);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	text-rendering: optimizeLegibility;
-	letter-spacing: normal;
-	font-smooth: auto;
+/* Legacy hooks retained so any component that still references
+   `.font-pixel` or `.pixel-btn` picks up the locked default (Space Grotesk).
+   The font-mode switcher was removed — the app ships with an opinionated
+   typography pair (Space Grotesk + JetBrains Mono) matching the website. */
+.font-pixel,
+.pixel-btn {
+	font-family: var(--font-ui);
 }

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -4,12 +4,9 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/logo.svg" type="image/svg+xml" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<!-- All typography is self-hosted (Space Grotesk + JetBrains Mono).
+		     See @font-face in theme/tokens.css. No CDN fetch at runtime. -->
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<!-- Self-hosted primary fonts (Space Grotesk + JetBrains Mono) are loaded
-		     via @font-face in theme/tokens.css. This <link> only pulls the pixel
-		     / retro faces users opt into via the font-mode switcher. -->
-		<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=Silkscreen:wght@400;700&family=Pixelify+Sans:wght@400..700&family=DotGothic16&family=Jersey+10&family=Tiny5&family=Workbench&family=Fira+Code:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Contrapunk</title>
 		<style>

--- a/ui/src/lib/components/ChainPanel.svelte
+++ b/ui/src/lib/components/ChainPanel.svelte
@@ -704,7 +704,7 @@
 
 	.plugin-value.plugin-id {
 		color: var(--color-text-dim);
-		font-family: monospace;
+		font-family: var(--font-code);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/ui/src/lib/components/ClapPluginPicker.svelte
+++ b/ui/src/lib/components/ClapPluginPicker.svelte
@@ -197,7 +197,7 @@
 	.plugin-path {
 		color: var(--color-text-dim);
 		font-size: var(--font-size-xs);
-		font-family: monospace;
+		font-family: var(--font-code);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/ui/src/lib/components/Fretboard.svelte
+++ b/ui/src/lib/components/Fretboard.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import { engine } from '$lib/stores/engine.svelte';
 	import { adapter } from '$lib/adapter';
+	import { ui } from '$lib/stores/ui.svelte';
+
+	/** Convert a MIDI number to a short name like "C4" or "F#5". */
+	function midiName(m: number): string {
+		const names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+		return names[((m % 12) + 12) % 12] + (Math.floor(m / 12) - 1);
+	}
 
 	// Standard tuning open string MIDI values [E2, A2, D3, G3, B3, E4]
 	const STANDARD_TUNING = [40, 45, 50, 55, 59, 64];
@@ -274,24 +281,39 @@
 		<!-- Harmony markers (magenta) -->
 		{#each harmonyMarkers as marker}
 			<g class="marker" class:flash={flashingHarmony.has(marker.midi)}>
-				<circle cx={marker.x} cy={marker.y} r="7.5" fill={COLOR_HARMONY} fill-opacity="0.22" />
-				<circle cx={marker.x} cy={marker.y} r="5" fill={COLOR_HARMONY} stroke={COLOR_HARMONY} stroke-width="1.5" />
+				<circle cx={marker.x} cy={marker.y} r="9" fill={COLOR_HARMONY} fill-opacity="0.22" />
+				<circle cx={marker.x} cy={marker.y} r="6.5" fill={COLOR_HARMONY} stroke={COLOR_HARMONY} stroke-width="1.5" />
+				{#if ui.showNoteLabels}
+					<text x={marker.x} y={marker.y + 2.5} class="marker-label" text-anchor="middle" fill="#f5e9c9">
+						{midiName(marker.midi)}
+					</text>
+				{/if}
 			</g>
 		{/each}
 
 		<!-- Borrowed markers (violet) -->
 		{#each borrowedMarkers as marker}
 			<g class="marker">
-				<circle cx={marker.x} cy={marker.y} r="7.5" fill={COLOR_BORROWED} fill-opacity="0.22" />
-				<circle cx={marker.x} cy={marker.y} r="5" fill={COLOR_BORROWED} stroke={COLOR_BORROWED} stroke-width="1.5" />
+				<circle cx={marker.x} cy={marker.y} r="9" fill={COLOR_BORROWED} fill-opacity="0.22" />
+				<circle cx={marker.x} cy={marker.y} r="6.5" fill={COLOR_BORROWED} stroke={COLOR_BORROWED} stroke-width="1.5" />
+				{#if ui.showNoteLabels}
+					<text x={marker.x} y={marker.y + 2.5} class="marker-label" text-anchor="middle" fill="#f5e9c9">
+						{midiName(marker.midi)}
+					</text>
+				{/if}
 			</g>
 		{/each}
 
 		<!-- Input markers (teal) — drawn last so they sit on top -->
 		{#each inputMarkers as marker}
 			<g class="marker" class:flash-input={flashingInput.has(marker.midi)}>
-				<circle cx={marker.x} cy={marker.y} r="7.5" fill={COLOR_INPUT} fill-opacity="0.28" />
-				<circle cx={marker.x} cy={marker.y} r="5" fill={COLOR_INPUT} stroke={COLOR_INPUT} stroke-width="1.5" />
+				<circle cx={marker.x} cy={marker.y} r="9" fill={COLOR_INPUT} fill-opacity="0.28" />
+				<circle cx={marker.x} cy={marker.y} r="6.5" fill={COLOR_INPUT} stroke={COLOR_INPUT} stroke-width="1.5" />
+				{#if ui.showNoteLabels}
+					<text x={marker.x} y={marker.y + 2.5} class="marker-label" text-anchor="middle" fill="#0a0612">
+						{midiName(marker.midi)}
+					</text>
+				{/if}
 			</g>
 		{/each}
 
@@ -325,6 +347,14 @@
 
 	.marker {
 		filter: drop-shadow(0 0 6px currentColor);
+	}
+
+	.marker-label {
+		font-family: var(--font-code);
+		font-size: 7.5px;
+		font-weight: 600;
+		pointer-events: none;
+		letter-spacing: 0;
 	}
 
 	.marker.flash-input circle {

--- a/ui/src/lib/components/Piano.svelte
+++ b/ui/src/lib/components/Piano.svelte
@@ -1,7 +1,19 @@
 <script lang="ts">
 	import { engine } from '$lib/stores/engine.svelte';
 	import { adapter } from '$lib/adapter';
+	import { ui } from '$lib/stores/ui.svelte';
 	import { getPianoKeyColor } from '$lib/theme/colors';
+
+	/** Contrast text color for a key based on which state is driving its fill.
+	 *  Input (teal) + default-cream fills are light → dark label.
+	 *  Harmony (magenta) + borrowed (violet) fills are mid-dark → light label.
+	 *  Un-lit black keys stay with the default pale-violet text. */
+	function labelColorFor(midi: number, isBlack: boolean): string {
+		if (engine.inputNotes.includes(midi)) return '#0a0612';    // dark on teal
+		if (engine.harmonyNotes.includes(midi)) return '#f5e9c9';  // cream on magenta
+		if (engine.borrowedNotes.includes(midi)) return '#f5e9c9'; // cream on violet
+		return isBlack ? 'var(--color-text-primary)' : 'var(--color-bg-deep)';
+	}
 
 	// MIDI range for standard 88-key piano: A0 (21) to C8 (108)
 	const PIANO_START = 21;
@@ -209,8 +221,8 @@
 				{#if inScale && !active}
 					<div class="scale-overlay"></div>
 				{/if}
-				{#if active}
-					<span class="key-label font-pixel">{midiToName(midi)}</span>
+				{#if active && ui.showNoteLabels}
+					<span class="key-label font-pixel" style:color={labelColorFor(midi, isBlackKey(midi))}>{midiToName(midi)}</span>
 				{/if}
 			</div>
 		{/each}
@@ -242,8 +254,8 @@
 				{#if inScale && !active}
 					<div class="scale-overlay"></div>
 				{/if}
-				{#if active}
-					<span class="key-label font-pixel">{midiToName(midi)}</span>
+				{#if active && ui.showNoteLabels}
+					<span class="key-label font-pixel" style:color={labelColorFor(midi, isBlackKey(midi))}>{midiToName(midi)}</span>
 				{/if}
 			</div>
 		{/each}

--- a/ui/src/lib/components/SettingsModal.svelte
+++ b/ui/src/lib/components/SettingsModal.svelte
@@ -1,25 +1,5 @@
 <script lang="ts">
-	import { ui, FONT_OPTIONS } from '$lib/stores/ui.svelte';
-
-	let fontOpen = $state(false);
-	let fontTriggerEl: HTMLDivElement | undefined = $state();
-
-	let currentFont = $derived(FONT_OPTIONS.find((o) => o.value === ui.fontMode) ?? FONT_OPTIONS[0]);
-
-	function toggleFont() {
-		fontOpen = !fontOpen;
-	}
-
-	function pickFont(value: typeof currentFont.value) {
-		ui.setFontMode(value);
-		fontOpen = false;
-	}
-
-	function onFontBlur(e: FocusEvent) {
-		if (fontTriggerEl && !fontTriggerEl.contains(e.relatedTarget as Node)) {
-			fontOpen = false;
-		}
-	}
+	import { ui } from '$lib/stores/ui.svelte';
 
 	/**
 	 * Preview value used while the user drags the scale slider. Committed
@@ -27,23 +7,42 @@
 	 * page doesn't re-zoom frame-by-frame during the drag.
 	 */
 	let previewScale = $state(ui.uiScale);
+	let previewFontScale = $state(ui.fontScale);
 
-	// Keep the preview in sync when the store is updated from elsewhere
+	// Keep the previews in sync when the store is updated from elsewhere
 	// (e.g. localStorage restore on init).
 	$effect(() => {
 		previewScale = ui.uiScale;
 	});
+	$effect(() => {
+		previewFontScale = ui.fontScale;
+	});
 
 	let previewPercent = $derived(Math.round(previewScale * 100));
 	let currentPercent = $derived(Math.round(ui.uiScale * 100));
+	let previewFontPercent = $derived(Math.round(previewFontScale * 100));
+	let currentFontPercent = $derived(Math.round(ui.fontScale * 100));
 
 	function onScaleInput(e: Event) {
 		const v = Number((e.target as HTMLInputElement).value);
 		if (Number.isFinite(v)) previewScale = v;
 	}
-
 	function onScaleCommit() {
 		ui.setUiScale(previewScale);
+	}
+
+	function onFontScaleInput(e: Event) {
+		const v = Number((e.target as HTMLInputElement).value);
+		if (Number.isFinite(v)) {
+			previewFontScale = v;
+			// Live-preview the typography without committing to localStorage.
+			if (typeof document !== 'undefined') {
+				document.documentElement.style.setProperty('--font-scale', String(v));
+			}
+		}
+	}
+	function onFontScaleCommit() {
+		ui.setFontScale(previewFontScale);
 	}
 
 	function toggleFx() {
@@ -53,6 +52,10 @@
 		} catch {
 			/* localStorage unavailable */
 		}
+	}
+
+	function toggleNoteLabels() {
+		ui.setShowNoteLabels(!ui.showNoteLabels);
 	}
 
 	function close() {
@@ -110,40 +113,41 @@
 					</div>
 
 					<div class="row">
-						<span class="row-label font-pixel">Font</span>
-						<div
-							class="row-control font-select"
-							bind:this={fontTriggerEl}
-							onfocusout={onFontBlur}
-							role="listbox"
-							tabindex="-1"
-						>
+						<label class="row-label font-pixel" for="settings-font-scale">Font size</label>
+						<div class="row-control">
+							<input
+								id="settings-font-scale"
+								class="scale-slider"
+								type="range"
+								min="0.75"
+								max="1.5"
+								step="0.05"
+								value={previewFontScale}
+								oninput={onFontScaleInput}
+								onchange={onFontScaleCommit}
+							/>
+							<span class="value font-pixel">
+								{previewFontPercent}%{#if previewFontPercent !== currentFontPercent}
+									<span class="pending">*</span>
+								{/if}
+							</span>
+						</div>
+					</div>
+
+					<div class="row">
+						<span class="row-label font-pixel">Note labels</span>
+						<div class="row-control">
 							<button
-								class="font-trigger pixel-btn"
-								class:open={fontOpen}
-								onclick={toggleFont}
+								class="pixel-btn font-pixel"
+								class:active={ui.showNoteLabels}
+								onclick={toggleNoteLabels}
 								type="button"
 							>
-								<span class="font-trigger-label font-pixel">{currentFont.label}</span>
-								<span class="font-trigger-sample font-{currentFont.value}">Aa 123</span>
-								<span class="font-trigger-arrow">{fontOpen ? '▴' : '▾'}</span>
+								{ui.showNoteLabels ? 'On' : 'Off'}
 							</button>
-
-							{#if fontOpen}
-								<div class="font-dropdown">
-									{#each FONT_OPTIONS as opt}
-										<button
-											class="font-option"
-											class:active={opt.value === ui.fontMode}
-											onclick={() => pickFont(opt.value)}
-											type="button"
-										>
-											<span class="font-option-label font-pixel">{opt.label}</span>
-											<span class="font-option-sample font-{opt.value}">Aa 123</span>
-										</button>
-									{/each}
-								</div>
-							{/if}
+							<span class="hint font-pixel">
+								{ui.showNoteLabels ? 'C4, D#5 on active keys' : 'Keys + frets only'}
+							</span>
 						</div>
 					</div>
 				</section>
@@ -238,7 +242,7 @@
 
 	.row {
 		display: grid;
-		grid-template-columns: 80px 1fr;
+		grid-template-columns: 90px 1fr;
 		align-items: center;
 		gap: 10px;
 	}
@@ -291,115 +295,6 @@
 		color: var(--color-accent-magenta);
 		margin-left: 2px;
 	}
-
-	/* Font dropdown */
-	.font-select {
-		position: relative;
-		flex: 1;
-	}
-
-	.font-trigger {
-		width: 100%;
-		display: grid;
-		grid-template-columns: 1fr auto auto;
-		align-items: center;
-		gap: 10px;
-		padding: 6px 10px;
-		font-size: var(--font-size-xs);
-		text-align: left;
-		background: var(--color-widget-bg);
-	}
-
-	.font-trigger.open {
-		border-color: var(--color-accent-cyan);
-		box-shadow: var(--glow-cyan);
-	}
-
-	.font-trigger-label {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.font-trigger-sample {
-		font-size: var(--font-size-sm);
-		color: var(--color-accent-cyan);
-		white-space: nowrap;
-	}
-
-	.font-trigger-arrow {
-		color: var(--color-accent-cyan);
-		font-size: var(--font-size-xs);
-	}
-
-	.font-dropdown {
-		position: absolute;
-		top: 100%;
-		left: 0;
-		right: 0;
-		z-index: 10;
-		background: var(--color-bg-panel);
-		border: 1px solid var(--color-accent-cyan);
-		border-top: none;
-		max-height: 240px;
-		overflow-y: auto;
-		box-shadow: var(--glow-cyan);
-	}
-
-	.font-option {
-		width: 100%;
-		display: grid;
-		grid-template-columns: 1fr auto;
-		align-items: center;
-		gap: 10px;
-		background: transparent;
-		border: none;
-		color: var(--color-text-primary);
-		font-size: var(--font-size-xs);
-		padding: 5px 10px;
-		cursor: pointer;
-		text-align: left;
-	}
-
-	.font-option:hover {
-		background: var(--color-accent-cyan);
-		color: var(--color-bg-deep);
-	}
-
-	.font-option:hover .font-option-sample {
-		color: var(--color-bg-deep);
-	}
-
-	.font-option.active {
-		color: var(--color-accent-magenta);
-	}
-
-	.font-option-label {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.font-option-sample {
-		font-size: var(--font-size-sm);
-		color: var(--color-accent-cyan);
-		white-space: nowrap;
-	}
-
-	/* Per-face preview rules for the font selector tiles. Each preview
-	   renders "Aa 123" in its own face so you can compare at a glance. */
-	.font-press-start { font-family: var(--font-press-start); -webkit-font-smoothing: none; text-rendering: optimizeSpeed; }
-	.font-vt323 { font-family: var(--font-vt323); -webkit-font-smoothing: antialiased; letter-spacing: 1px; }
-	.font-silkscreen { font-family: var(--font-silkscreen); -webkit-font-smoothing: none; text-rendering: optimizeSpeed; }
-	.font-pixelify { font-family: var(--font-pixelify); -webkit-font-smoothing: antialiased; }
-	.font-dotgothic { font-family: var(--font-dotgothic); -webkit-font-smoothing: none; text-rendering: optimizeSpeed; }
-	.font-jersey { font-family: var(--font-jersey); -webkit-font-smoothing: antialiased; }
-	.font-tiny5 { font-family: var(--font-tiny5); -webkit-font-smoothing: none; text-rendering: optimizeSpeed; }
-	.font-workbench { font-family: var(--font-workbench); -webkit-font-smoothing: antialiased; }
-	.font-jetbrains { font-family: var(--font-jetbrains); -webkit-font-smoothing: antialiased; }
-	.font-fira { font-family: var(--font-fira); -webkit-font-smoothing: antialiased; }
-	.font-plex { font-family: var(--font-plex); -webkit-font-smoothing: antialiased; }
-	.font-clean { font-family: var(--font-reading); -webkit-font-smoothing: antialiased; letter-spacing: normal; }
 
 	.hint {
 		font-size: var(--font-size-xs);

--- a/ui/src/lib/stores/ui.svelte.ts
+++ b/ui/src/lib/stores/ui.svelte.ts
@@ -10,44 +10,13 @@ import { platformName } from '$lib/adapter';
 // === Persistence ===
 
 const SCALE_KEY = 'contrapunk-ui-scale';
-const FONT_KEY = 'contrapunk-ui-font';
+const FONT_SCALE_KEY = 'contrapunk-font-scale';
+const NOTE_LABELS_KEY = 'contrapunk-show-note-labels';
 
 const MIN_SCALE = 0.75;
 const MAX_SCALE = 2.0;
-
-export type FontMode =
-	| 'press-start'
-	| 'vt323'
-	| 'silkscreen'
-	| 'pixelify'
-	| 'dotgothic'
-	| 'jersey'
-	| 'tiny5'
-	| 'workbench'
-	| 'jetbrains'
-	| 'fira'
-	| 'plex'
-	| 'clean';
-
-export const FONT_OPTIONS: { value: FontMode; label: string; kind: 'pixel' | 'mono' | 'clean' }[] = [
-	// Pixel / retro
-	{ value: 'press-start', label: 'Press Start', kind: 'pixel' },
-	{ value: 'vt323', label: 'VT323', kind: 'pixel' },
-	{ value: 'silkscreen', label: 'Silkscreen', kind: 'pixel' },
-	{ value: 'pixelify', label: 'Pixelify', kind: 'pixel' },
-	{ value: 'dotgothic', label: 'DotGothic16', kind: 'pixel' },
-	{ value: 'jersey', label: 'Jersey 10', kind: 'pixel' },
-	{ value: 'tiny5', label: 'Tiny5', kind: 'pixel' },
-	{ value: 'workbench', label: 'Workbench', kind: 'pixel' },
-	// Readable mono
-	{ value: 'jetbrains', label: 'JetBrains Mono', kind: 'mono' },
-	{ value: 'fira', label: 'Fira Code', kind: 'mono' },
-	{ value: 'plex', label: 'IBM Plex Mono', kind: 'mono' },
-	// System sans
-	{ value: 'clean', label: 'Clean', kind: 'clean' }
-];
-
-const FONT_CLASSES = FONT_OPTIONS.map((o) => `font-${o.value}`);
+const MIN_FONT_SCALE = 0.75;
+const MAX_FONT_SCALE = 1.5;
 
 // === UI Store (Svelte 5 runes) ===
 
@@ -75,8 +44,11 @@ class UiStore {
 	// -- Density / readability --
 	/** Global UI zoom factor. Applied via CSS `zoom` on <html>. */
 	uiScale = $state(1.0);
-	/** Which font family the whole UI uses. See FONT_OPTIONS. */
-	fontMode = $state<FontMode>('press-start');
+	/** Typography-only scale. Multiplies --font-size-* tokens without
+	 *  affecting layout geometry the way uiScale does. */
+	fontScale = $state(1.0);
+	/** Whether to show "C4", "D#5" etc. labels on active piano keys + fretboard notes. */
+	showNoteLabels = $state(true);
 
 	/**
 	 * Toggle animations on/off and apply the reduced-motion class
@@ -124,38 +96,23 @@ class UiStore {
 		});
 	}
 
-	/**
-	 * Mark the app as initialized (call after adapter.init() succeeds).
-	 */
 	markInitialized() {
 		this.initialized = true;
 		this.error = null;
 	}
 
-	/**
-	 * Set an error state for display.
-	 */
 	setError(message: string) {
 		this.error = message;
 	}
 
-	/**
-	 * Clear the error state.
-	 */
 	clearError() {
 		this.error = null;
 	}
 
-	/**
-	 * Toggle sidebar collapsed state.
-	 */
 	toggleSidebar() {
 		this.sidebarCollapsed = !this.sidebarCollapsed;
 	}
 
-	/**
-	 * Set the active panel (e.g., 'play', 'craft', 'settings').
-	 */
 	setActivePanel(panel: string) {
 		this.activePanel = panel;
 	}
@@ -190,34 +147,41 @@ class UiStore {
 		document.documentElement.style.setProperty('--ui-scale', String(this.uiScale));
 	}
 
-	// === Font mode ===
+	// === Font scale (typography-only, independent of uiScale) ===
 
-	setFontMode(mode: FontMode) {
-		this.fontMode = mode;
-		this.applyFontMode();
+	setFontScale(scale: number) {
+		const clamped = Math.max(MIN_FONT_SCALE, Math.min(MAX_FONT_SCALE, scale));
+		this.fontScale = clamped;
+		this.applyFontScale();
 		try {
-			localStorage.setItem(FONT_KEY, mode);
+			localStorage.setItem(FONT_SCALE_KEY, String(clamped));
 		} catch {
 			/* localStorage unavailable */
 		}
 	}
 
-	/** Cycle through the available font modes (used by the compact
-	 *  keyboard-style toggle button). */
-	cycleFontMode() {
-		const idx = FONT_OPTIONS.findIndex((o) => o.value === this.fontMode);
-		const next = FONT_OPTIONS[(idx + 1) % FONT_OPTIONS.length].value;
-		this.setFontMode(next);
-	}
-
-	applyFontMode() {
+	applyFontScale() {
 		if (typeof document === 'undefined') return;
-		const body = document.body;
-		FONT_CLASSES.forEach((c) => body.classList.remove(c));
-		body.classList.add(`font-${this.fontMode}`);
+		document.documentElement.style.setProperty('--font-scale', String(this.fontScale));
 	}
 
-	/** Restore persisted density + font preferences from localStorage. */
+	// === Note labels ===
+
+	setShowNoteLabels(on: boolean) {
+		this.showNoteLabels = on;
+		try {
+			localStorage.setItem(NOTE_LABELS_KEY, on ? 'on' : 'off');
+		} catch {
+			/* localStorage unavailable */
+		}
+	}
+
+	/** Restore persisted appearance preferences from localStorage.
+	 *  Font family is no longer user-configurable — the app is locked
+	 *  to the website's typography pair (Space Grotesk + JetBrains Mono).
+	 *  Also cleans up the legacy `contrapunk-ui-font` key + any stale
+	 *  `body.font-*` class applied by a previous app version so existing
+	 *  installs don't keep rendering Press Start 2P. */
 	restoreAppearance() {
 		try {
 			const savedScale = localStorage.getItem(SCALE_KEY);
@@ -227,19 +191,30 @@ class UiStore {
 					this.uiScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, n));
 				}
 			}
-			const savedFont = localStorage.getItem(FONT_KEY);
-			const valid = FONT_OPTIONS.map((o) => o.value);
-			if (savedFont && (valid as string[]).includes(savedFont)) {
-				this.fontMode = savedFont as FontMode;
-			} else if (savedFont === 'pixel') {
-				// Legacy value from the two-mode era.
-				this.fontMode = 'press-start';
+			const savedFontScale = localStorage.getItem(FONT_SCALE_KEY);
+			if (savedFontScale) {
+				const n = parseFloat(savedFontScale);
+				if (Number.isFinite(n)) {
+					this.fontScale = Math.max(MIN_FONT_SCALE, Math.min(MAX_FONT_SCALE, n));
+				}
 			}
+			const savedLabels = localStorage.getItem(NOTE_LABELS_KEY);
+			if (savedLabels === 'off') this.showNoteLabels = false;
+
+			// Legacy cleanup — strip any font-mode body class applied by
+			// older builds and drop the stale localStorage key.
+			if (typeof document !== 'undefined') {
+				const classes = Array.from(document.body.classList);
+				for (const c of classes) {
+					if (c.startsWith('font-')) document.body.classList.remove(c);
+				}
+			}
+			localStorage.removeItem('contrapunk-ui-font');
 		} catch {
 			/* localStorage unavailable */
 		}
 		this.applyUiScale();
-		this.applyFontMode();
+		this.applyFontScale();
 	}
 }
 

--- a/ui/src/lib/theme/tokens.css
+++ b/ui/src/lib/theme/tokens.css
@@ -7,9 +7,8 @@
 /* Self-hosted primary fonts — match the redesigned contrapunk.com.
    Files live in /static/fonts/ and are served from the app origin so
    typography works offline and in the Tauri desktop build without
-   talking to fonts.gstatic.com. The pixel / retro faces continue to
-   load from Google Fonts via <link> in app.html — users opt into them
-   through the font-mode switcher. */
+   talking to fonts.gstatic.com. The app is locked to this pair
+   (Space Grotesk + JetBrains Mono) — no runtime font switcher. */
 @font-face {
 	font-family: 'Space Grotesk';
 	font-style: normal;
@@ -112,23 +111,12 @@
 	--glow-cyan: 0 0 8px #33ddff55, 0 0 20px #33ddff22;
 	--glow-teal: 0 0 8px #00ccaa55, 0 0 20px #00ccaa22;
 
-	/* === Typography === */
-	/* Pixel / retro faces (opt-in via body.font-* classes) */
-	--font-press-start: 'Press Start 2P', monospace;
-	--font-vt323: 'VT323', monospace;
-	--font-silkscreen: 'Silkscreen', monospace;
-	--font-pixelify: 'Pixelify Sans', sans-serif;
-	--font-dotgothic: 'DotGothic16', monospace;
-	--font-jersey: 'Jersey 10', sans-serif;
-	--font-tiny5: 'Tiny5', monospace;
-	--font-workbench: 'Workbench', sans-serif;
-	/* Readable mono — JetBrains Mono is self-hosted (see @font-face above) */
-	--font-jetbrains: 'JetBrains Mono', ui-monospace, monospace;
-	--font-fira: 'Fira Code', monospace;
-	--font-plex: 'IBM Plex Mono', monospace;
-	/* Readable sans — Space Grotesk is self-hosted; matches the website */
+	/* === Typography ===
+	   Locked to an opinionated pair (Space Grotesk + JetBrains Mono)
+	   matching the redesigned contrapunk.com. Self-hosted via @font-face
+	   above — no CDN fetch at runtime. */
 	--font-grotesk: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
-	/* System fallback */
+	--font-jetbrains: 'JetBrains Mono', ui-monospace, monospace;
 	--font-reading: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 
 	/* Semantic font roles — mirror the redesigned contrapunk.com.
@@ -141,28 +129,25 @@
 	--font-code: var(--font-jetbrains);
 	--font-mono: var(--font-jetbrains);
 	--font-body: var(--font-grotesk);
-
-	/* Legacy alias — many components reference --font-pixel. Default now
-	   routes to Space Grotesk so the app visually matches the website.
-	   The body font-mode switcher (body.font-press-start / .font-vt323 /
-	   etc.) still remaps --font-pixel per opt-in mode, so pixel-font fans
-	   stay happy. */
+	/* Legacy alias for components that still reference --font-pixel. */
 	--font-pixel: var(--font-grotesk);
 
 	/* Base font sizes scale with viewport so the UI stays proportional
 	   on any monitor. clamp(min, responsive, max) keeps them legible
-	   everywhere without going microscopic or huge. Applied to the
-	   whole UI; multiplied by `--ui-scale` (see `html { zoom }` in
-	   app.css) for user-controlled density. */
-	--font-size-xs: clamp(8px, 0.75vmin + 6px, 14px);
-	--font-size-sm: clamp(10px, 0.9vmin + 7px, 16px);
-	--font-size-md: clamp(12px, 1.1vmin + 8px, 20px);
-	--font-size-lg: clamp(16px, 1.5vmin + 10px, 28px);
-	--font-size-xl: clamp(24px, 2.2vmin + 14px, 40px);
+	   everywhere without going microscopic or huge. Multiplied by
+	   --font-scale for the user-controlled font-size slider (range
+	   0.75–1.5) — independent of --ui-scale which zooms layout. */
+	--font-size-xs: calc(clamp(8px, 0.75vmin + 6px, 14px) * var(--font-scale));
+	--font-size-sm: calc(clamp(10px, 0.9vmin + 7px, 16px) * var(--font-scale));
+	--font-size-md: calc(clamp(12px, 1.1vmin + 8px, 20px) * var(--font-scale));
+	--font-size-lg: calc(clamp(16px, 1.5vmin + 10px, 28px) * var(--font-scale));
+	--font-size-xl: calc(clamp(24px, 2.2vmin + 14px, 40px) * var(--font-scale));
 
-	/* User-controlled global UI scale. Applied via `html { zoom: var(--ui-scale) }`.
-	   Defaults to 1.0; range in the UI slider is 0.75–2.0. */
+	/* User-controlled scales.
+	   --ui-scale  → zooms entire layout via html { zoom }. Range 0.75–2.0.
+	   --font-scale → multiplies font sizes only. Range 0.75–1.5. */
 	--ui-scale: 1;
+	--font-scale: 1;
 }
 
 /* === Performance Toggle ===

--- a/ui/src/routes/debug/guitar-midi/+page.svelte
+++ b/ui/src/routes/debug/guitar-midi/+page.svelte
@@ -972,7 +972,7 @@
 
 <style>
 	.debug-page {
-		font-family: 'SF Mono', 'Fira Code', monospace;
+		font-family: var(--font-code);
 		background: #0a0a0f;
 		color: #e0e0e0;
 		min-height: 100vh;

--- a/ui/src/routes/debug/integration-test/+page.svelte
+++ b/ui/src/routes/debug/integration-test/+page.svelte
@@ -439,7 +439,7 @@
 
 <style>
 	.page {
-		font-family: 'SF Mono', 'Fira Code', monospace;
+		font-family: var(--font-code);
 		background: #0a0a0f;
 		color: #e0e0e0;
 		min-height: 100vh;


### PR DESCRIPTION
## Summary

Closes #49. Locks the app's typography to the website's opinionated pair (Space Grotesk + JetBrains Mono) and adds a font-size slider + note-labels toggle in Settings.

### Typography locked
- Drops the font-mode switcher (11 pixel/retro options) from Settings
- `ui.svelte.ts`: removes `FontMode`, `FONT_OPTIONS`, `setFontMode`, `cycleFontMode`, `applyFontMode`
- `app.css`: removes all `body.font-*` override rules
- `app.html`: drops the Google Fonts `<link>` entirely — zero CDN font fetches at runtime
- `tokens.css`: drops 10 unused pixel/retro `--font-*` var declarations
- **Legacy cleanup**: `restoreAppearance()` strips any stale `body.font-*` class + removes the old `contrapunk-ui-font` localStorage key, so existing installs stop rendering Press Start 2P without needing to clear localStorage manually

### Font-size slider
- New `--font-scale` CSS var (default 1.0, range 0.75–1.5)
- All `--font-size-*` tokens wrapped in `calc(clamp(...) * var(--font-scale))`
- Independent of `--ui-scale` — font-size slider adjusts typography only, UI scale slider zooms layout
- Live preview while dragging, commits on release, persists in localStorage

### Note-labels toggle
- New `ui.showNoteLabels` state (default on), toggle in Settings
- Piano: labels on active keys respect the toggle; color auto-contrasts against the current fill (dark on teal input, cream on magenta harmony + violet borrowed)
- Fretboard: marker circles slightly enlarged to fit the centered note-name label, same contrast rules

### Hardcoded font cleanup
- `ClapPluginPicker.svelte`, `ChainPanel.svelte`: `font-family: monospace` → `var(--font-code)`
- debug pages: `'SF Mono', 'Fira Code', monospace` → `var(--font-code)`

## Test plan

- [ ] Existing installs with persisted `contrapunk-ui-font=press-start` now render Space Grotesk after first load (localStorage migration fires via restoreAppearance)
- [ ] Settings modal: no font picker, has Font size slider + Note labels toggle + UI scale slider + Visual FX toggle
- [ ] Font size slider: live preview during drag, commits on release, persists across reload
- [ ] Note labels toggle OFF: keys + fret markers show no text
- [ ] Piano: teal input key shows dark text label; magenta harmony + violet borrowed show cream text
- [ ] Fretboard: each marker has its note name centered, readable against its fill
- [ ] `npm run check` clean (verified, 0 errors)
- [ ] Browser network tab: no requests to fonts.gstatic.com

## Files

- `ui/src/app.css`, `ui/src/app.html`, `ui/src/lib/theme/tokens.css` — typography lock
- `ui/src/lib/stores/ui.svelte.ts` — font-mode strip + fontScale + showNoteLabels + legacy cleanup
- `ui/src/lib/components/SettingsModal.svelte` — rewritten without font picker
- `ui/src/lib/components/Piano.svelte` — label toggle + contrast
- `ui/src/lib/components/Fretboard.svelte` — active-marker labels + contrast
- `ui/src/lib/components/ClapPluginPicker.svelte`, `ChainPanel.svelte` — font-family: monospace → var(--font-code)
- `ui/src/routes/debug/{guitar-midi,integration-test}/+page.svelte` — same

Milestone: [v1.1 · website-launch readiness](https://github.com/contrapunk-audio/contrapunk/milestone/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)