### PR TITLE
refactor(ui): .font-pixel → semantic role classes (font-ui / font-code)

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -20,11 +20,28 @@ body {
 	text-rendering: optimizeLegibility;
 }
 
-/* Legacy hooks retained so any component that still references
-   `.font-pixel` or `.pixel-btn` picks up the locked default (Space Grotesk).
-   The font-mode switcher was removed — the app ships with an opinionated
-   typography pair (Space Grotesk + JetBrains Mono) matching the website. */
-.font-pixel,
+/* Semantic role utilities. See tokens.css for the --font-* variable
+   definitions and which font each role uses.
+     .font-ui   — buttons, labels, chrome, nav, form inputs
+     .font-code — technical readouts (note names, BPM, stats, IDs)
+     .font-body — prose / paragraphs (rarely needed; body already uses it)
+     .font-display — page titles / hero headings
+   Chrome + technical readouts keep the retro pixel-rendering
+   aesthetic (no antialiasing, optimizeSpeed). Prose and display don't. */
+.font-ui,
 .pixel-btn {
 	font-family: var(--font-ui);
+	-webkit-font-smoothing: none;
+	text-rendering: optimizeSpeed;
+}
+.font-code {
+	font-family: var(--font-code);
+	-webkit-font-smoothing: none;
+	text-rendering: optimizeSpeed;
+}
+.font-body {
+	font-family: var(--font-body);
+}
+.font-display {
+	font-family: var(--font-display);
 }

--- a/ui/src/lib/components/ActiveNotes.svelte
+++ b/ui/src/lib/components/ActiveNotes.svelte
@@ -22,39 +22,39 @@
 </script>
 
 <div class="card">
-	<div class="card-header font-pixel">Notes</div>
+	<div class="card-header font-ui">Notes</div>
 
 	<!-- Chord name (prominent) -->
 	{#if engine.chordName}
-		<div class="chord-name font-pixel">{engine.chordName}</div>
+		<div class="chord-name font-code">{engine.chordName}</div>
 	{/if}
 
 	<!-- Interchange source -->
 	{#if engine.lastBorrowedFrom}
-		<div class="borrowed-from font-pixel">from {engine.lastBorrowedFrom}</div>
+		<div class="borrowed-from font-code">from {engine.lastBorrowedFrom}</div>
 	{/if}
 
 	<!-- Input notes -->
 	<div class="note-section">
-		<span class="section-label font-pixel">INPUT</span>
+		<span class="section-label font-ui">INPUT</span>
 		{#if hasInput}
-			<span class="note-list input-notes font-pixel">
+			<span class="note-list input-notes font-code">
 				{inputNames.join('  ')}
 			</span>
 		{:else}
-			<span class="note-none font-pixel">(none)</span>
+			<span class="note-none font-code">(none)</span>
 		{/if}
 	</div>
 
 	<!-- Harmony notes -->
 	<div class="note-section">
-		<span class="section-label font-pixel">HARMONY</span>
+		<span class="section-label font-ui">HARMONY</span>
 		{#if hasHarmony}
-			<span class="note-list harmony-notes font-pixel">
+			<span class="note-list harmony-notes font-code">
 				{harmonyNames.join('  ')}
 			</span>
 		{:else}
-			<span class="note-none font-pixel">(none)</span>
+			<span class="note-none font-code">(none)</span>
 		{/if}
 	</div>
 </div>

--- a/ui/src/lib/components/ChainPanel.svelte
+++ b/ui/src/lib/components/ChainPanel.svelte
@@ -25,45 +25,45 @@
 
 <div class="chain-wrap">
 	<div class="chain-header-row">
-		<div class="chain-header font-pixel">Audio chain</div>
-		<button class="pixel-btn font-pixel add-plugin-btn" onclick={() => (pickerOpen = true)}>
+		<div class="chain-header font-ui">Audio chain</div>
+		<button class="pixel-btn font-ui add-plugin-btn" onclick={() => (pickerOpen = true)}>
 			+ Plugin
 		</button>
 	</div>
 
 	<!-- Signal-flow strip: dynamic based on chain state -->
 	<div class="flow">
-		<div class="flow-node source font-pixel">
+		<div class="flow-node source font-ui">
 			<div class="flow-title">Harmony</div>
 			<div class="flow-sub">MIDI</div>
 		</div>
 		{#each chainStore.blocks as b, i (i + ':' + b.typeId)}
-			<div class="flow-arrow font-pixel">━━▶</div>
+			<div class="flow-arrow font-ui">━━▶</div>
 			{#if b.typeId === 'builtin.synth'}
-				<div class="flow-node synth-node font-pixel">
+				<div class="flow-node synth-node font-ui">
 					<div class="flow-title">Synth</div>
 					<div class="flow-sub">8-voice</div>
 				</div>
 			{:else if b.typeId === 'builtin.delay'}
-				<div class="flow-node delay-node font-pixel" class:active={delay.enabled}>
+				<div class="flow-node delay-node font-ui" class:active={delay.enabled}>
 					<div class="flow-title">Delay</div>
 					<div class="flow-sub">{delay.enabled ? 'on' : 'bypass'}</div>
 				</div>
 			{:else if b.typeId === 'builtin.reverb'}
-				<div class="flow-node reverb-node font-pixel" class:active={reverb.enabled}>
+				<div class="flow-node reverb-node font-ui" class:active={reverb.enabled}>
 					<div class="flow-title">Reverb</div>
 					<div class="flow-sub">{reverb.enabled ? 'on' : 'bypass'}</div>
 				</div>
 			{:else}
 				<!-- Plugin flow node -->
-				<div class="flow-node plugin-node font-pixel" title={b.typeId}>
+				<div class="flow-node plugin-node font-ui" title={b.typeId}>
 					<div class="flow-title">{b.name}</div>
 					<div class="flow-sub">CLAP</div>
 				</div>
 			{/if}
 		{/each}
-		<div class="flow-arrow font-pixel">━━▶</div>
-		<div class="flow-node sink font-pixel">
+		<div class="flow-arrow font-ui">━━▶</div>
+		<div class="flow-node sink font-ui">
 			<div class="flow-title">Output</div>
 			<div class="flow-sub">Speakers</div>
 		</div>
@@ -72,9 +72,9 @@
 	<!-- Synth rack: Serum-inspired -->
 	<div class="rack">
 		<div class="rack-header">
-			<span class="rack-title font-pixel">Synth</span>
+			<span class="rack-title font-ui">Synth</span>
 			<button
-				class="pixel-btn power-btn font-pixel"
+				class="pixel-btn power-btn font-ui"
 				class:active={synth.enabled}
 				onclick={() => synth.setEnabled(!synth.enabled)}
 				title={synth.enabled ? 'Bypass synth' : 'Enable synth'}
@@ -86,7 +86,7 @@
 		<div class="rack-grid">
 			<!-- OSC section -->
 			<section class="rack-section osc">
-				<div class="section-label font-pixel">Osc</div>
+				<div class="section-label font-ui">Osc</div>
 				<WaveformView waveform={synth.waveform} height={60} />
 				<PixelSelect
 					options={waveformOptions}
@@ -98,7 +98,7 @@
 
 			<!-- FILTER section -->
 			<section class="rack-section filter">
-				<div class="section-label font-pixel">Filter</div>
+				<div class="section-label font-ui">Filter</div>
 				<div class="knob-row">
 					<Knob
 						label="Cutoff"
@@ -129,7 +129,7 @@
 
 			<!-- ENV section -->
 			<section class="rack-section env">
-				<div class="section-label font-pixel">Env</div>
+				<div class="section-label font-ui">Env</div>
 				<EnvelopeView
 					attackMs={synth.attackMs}
 					decayMs={synth.decayMs}
@@ -191,7 +191,7 @@
 
 			<!-- AMP section -->
 			<section class="rack-section amp">
-				<div class="section-label font-pixel">Amp</div>
+				<div class="section-label font-ui">Amp</div>
 				<div class="knob-row single">
 					<Knob
 						label="Master"
@@ -209,7 +209,7 @@
 			</section>
 		</div>
 
-		<div class="rack-footer font-pixel">
+		<div class="rack-footer font-ui">
 			Drag knobs ↕ • Shift = fine • Double-click = reset
 		</div>
 	</div>
@@ -219,9 +219,9 @@
 	<!-- Delay rack -->
 	<div class="rack delay-rack">
 		<div class="rack-header">
-			<span class="rack-title delay-title font-pixel">Delay</span>
+			<span class="rack-title delay-title font-ui">Delay</span>
 			<button
-				class="pixel-btn power-btn font-pixel"
+				class="pixel-btn power-btn font-ui"
 				class:active={delay.enabled}
 				onclick={() => delay.setEnabled(!delay.enabled)}
 				title={delay.enabled ? 'Bypass delay' : 'Enable delay'}
@@ -273,9 +273,9 @@
 	<!-- Reverb rack -->
 	<div class="rack reverb-rack">
 		<div class="rack-header">
-			<span class="rack-title reverb-title font-pixel">Reverb</span>
+			<span class="rack-title reverb-title font-ui">Reverb</span>
 			<button
-				class="pixel-btn power-btn font-pixel"
+				class="pixel-btn power-btn font-ui"
 				class:active={reverb.enabled}
 				onclick={() => reverb.setEnabled(!reverb.enabled)}
 				title={reverb.enabled ? 'Bypass reverb' : 'Enable reverb'}
@@ -330,10 +330,10 @@
 			{@const pluginId = parsePluginId(b.typeId)}
 			<div class="rack plugin-rack">
 				<div class="rack-header">
-					<span class="rack-title plugin-title font-pixel">{b.name}</span>
+					<span class="rack-title plugin-title font-ui">{b.name}</span>
 					<div class="plugin-actions">
 						<button
-							class="pixel-btn font-pixel plugin-open-btn"
+							class="pixel-btn font-ui plugin-open-btn"
 							onclick={() => pluginId !== null && chainStore.openPluginGui(pluginId)}
 							disabled={pluginId === null}
 							title={pluginId === null ? 'Plugin has no id' : 'Open plugin window'}
@@ -341,7 +341,7 @@
 							Open UI
 						</button>
 						<button
-							class="pixel-btn font-pixel plugin-remove-btn"
+							class="pixel-btn font-ui plugin-remove-btn"
 							onclick={() => chainStore.removeAt(i)}
 							title="Remove from chain"
 						>
@@ -349,14 +349,14 @@
 						</button>
 					</div>
 				</div>
-				<div class="plugin-body font-pixel">
+				<div class="plugin-body font-ui">
 					<div class="plugin-row">
 						<span class="plugin-label">Type</span>
 						<span class="plugin-value">CLAP</span>
 					</div>
 					<div class="plugin-row">
 						<span class="plugin-label">Plugin ID</span>
-						<span class="plugin-value plugin-id" title={b.typeId}>{b.typeId}</span>
+						<span class="plugin-value plugin-id font-code" title={b.typeId}>{b.typeId}</span>
 					</div>
 				</div>
 			</div>

--- a/ui/src/lib/components/ClapPluginPicker.svelte
+++ b/ui/src/lib/components/ClapPluginPicker.svelte
@@ -43,29 +43,29 @@
 		}}
 	></div>
 	<div class="modal" role="dialog" aria-label="CLAP plugin picker">
-		<div class="modal-header font-pixel">
+		<div class="modal-header font-ui">
 			<span>Add CLAP plugin</span>
-			<button class="pixel-btn font-pixel" onclick={() => (open = false)}>X</button>
+			<button class="pixel-btn font-ui" onclick={() => (open = false)}>X</button>
 		</div>
 		<div class="modal-body">
 			<input
-				class="search font-pixel"
+				class="search font-ui"
 				type="text"
 				placeholder="Search…"
 				bind:value={search}
 				autofocus
 			/>
 			{#if chainStore.loadingPlugins}
-				<div class="status font-pixel">Scanning…</div>
+				<div class="status font-ui">Scanning…</div>
 			{:else if chainStore.clapPlugins.length === 0}
-				<div class="status font-pixel">
+				<div class="status font-ui">
 					No .clap plugins found on disk.<br />
 					Install a CLAP plugin, then press Rescan.
 				</div>
 			{:else}
 				<div class="plugin-list">
 					{#each filtered as p (p.path)}
-						<button class="plugin-row font-pixel" onclick={() => addPlugin(p)}>
+						<button class="plugin-row font-ui" onclick={() => addPlugin(p)}>
 							<div class="plugin-name">{p.name}</div>
 							<div class="plugin-meta">
 								{p.vendor || '—'}
@@ -73,16 +73,16 @@
 									· {p.version}
 								{/if}
 							</div>
-							<div class="plugin-path">{p.path}</div>
+							<div class="plugin-path font-code">{p.path}</div>
 						</button>
 					{/each}
 				</div>
 			{/if}
 			{#if error}
-				<div class="error font-pixel">{error}</div>
+				<div class="error font-ui">{error}</div>
 			{/if}
 		</div>
-		<div class="modal-footer font-pixel">
+		<div class="modal-footer font-ui">
 			<button
 				class="pixel-btn"
 				disabled={chainStore.loadingPlugins}

--- a/ui/src/lib/components/ControlPanel.svelte
+++ b/ui/src/lib/components/ControlPanel.svelte
@@ -111,7 +111,7 @@
 
 <!-- Key dropdown + auto toggle -->
 <div class="card">
-	<div class="card-header font-pixel">
+	<div class="card-header font-ui">
 		<span>Key</span>
 		<button
 			class="pixel-btn auto-key-btn"
@@ -128,7 +128,7 @@
 <!-- Mode + Octave (side by side) -->
 <div class="row-2col">
 	<div class="card">
-		<div class="card-header font-pixel">Mode</div>
+		<div class="card-header font-ui">Mode</div>
 		<PixelSelect
 			options={modeOptions}
 			value={engine.mode}
@@ -137,7 +137,7 @@
 		/>
 	</div>
 	<div class="card">
-		<div class="card-header font-pixel">Octave</div>
+		<div class="card-header font-ui">Octave</div>
 		<PixelSelect
 			options={octaveOptions}
 			value={engine.octaveMode}
@@ -151,7 +151,7 @@
 {#if engine.mode === 'StrictCounterpoint'}
 	<div class="row-2col">
 		<div class="card">
-			<div class="card-header font-pixel">Species</div>
+			<div class="card-header font-ui">Species</div>
 			<PixelSelect
 				options={speciesOptions}
 				value={engine.counterpointSpecies}
@@ -160,7 +160,7 @@
 			/>
 		</div>
 		<div class="card">
-			<div class="card-header font-pixel">Strictness</div>
+			<div class="card-header font-ui">Strictness</div>
 			<PixelSelect
 				options={strictnessOptions}
 				value={engine.counterpointStrictness}
@@ -174,7 +174,7 @@
 <!-- Scale Family + Scale Mode in family (side by side) -->
 <div class="row-2col">
 	<div class="card">
-		<div class="card-header font-pixel">Family</div>
+		<div class="card-header font-ui">Family</div>
 		<PixelSelect
 			options={familyOptions}
 			value={currentFamily}
@@ -183,7 +183,7 @@
 		/>
 	</div>
 	<div class="card">
-		<div class="card-header font-pixel">Scale</div>
+		<div class="card-header font-ui">Scale</div>
 		<PixelSelect
 			options={scaleInFamilyOptions}
 			value={engine.scaleMode}
@@ -196,7 +196,7 @@
 <!-- Voice Count + Voice Position (side by side) -->
 <div class="row-2col">
 	<div class="card">
-		<div class="card-header font-pixel">Voices</div>
+		<div class="card-header font-ui">Voices</div>
 		<PixelSelect
 			options={voiceCountOptions}
 			value={String(engine.voiceCount)}
@@ -205,7 +205,7 @@
 		/>
 	</div>
 	<div class="card">
-		<div class="card-header font-pixel">You play</div>
+		<div class="card-header font-ui">You play</div>
 		{#if engine.voiceCount > 1}
 			<PixelSelect
 				options={voicePositionOptions}
@@ -214,7 +214,7 @@
 				onchange={onVoicePositionChange}
 			/>
 		{:else}
-			<span class="inline-note font-pixel">Solo melody</span>
+			<span class="inline-note font-ui">Solo melody</span>
 		{/if}
 	</div>
 </div>
@@ -222,7 +222,7 @@
 <!-- Voice Leading + Interchange (side by side) -->
 <div class="row-2col">
 	<div class="card">
-		<div class="card-header font-pixel">
+		<div class="card-header font-ui">
 			<span>Voice Leading</span>
 			<button
 				class="pixel-btn toggle-btn"
@@ -242,7 +242,7 @@
 		{/if}
 	</div>
 	<div class="card">
-		<div class="card-header font-pixel">
+		<div class="card-header font-ui">
 			<span>Interchange</span>
 			<button
 				class="pixel-btn toggle-btn"
@@ -254,7 +254,7 @@
 		</div>
 		{#if engine.interchangeEnabled}
 			<div class="range-row">
-				<span class="range-label font-pixel">Rng</span>
+				<span class="range-label font-ui">Rng</span>
 				<input
 					type="range"
 					min="1"
@@ -264,7 +264,7 @@
 					oninput={(e) => engine.setInterchange(true, parseInt((e.target as HTMLInputElement).value, 10))}
 					class="pixel-range"
 				/>
-				<span class="range-label font-pixel">{engine.interchangeRange}</span>
+				<span class="range-label font-code">{engine.interchangeRange}</span>
 			</div>
 		{/if}
 	</div>
@@ -272,9 +272,9 @@
 
 <!-- Detune (full width) -->
 <div class="card">
-	<div class="card-header font-pixel">Detune</div>
+	<div class="card-header font-ui">Detune</div>
 	<div class="range-row">
-		<span class="range-label font-pixel">{engine.detuneCents > 0 ? '+' : ''}{engine.detuneCents}¢</span>
+		<span class="range-label font-code">{engine.detuneCents > 0 ? '+' : ''}{engine.detuneCents}¢</span>
 		<input
 			type="range"
 			min="-100"

--- a/ui/src/lib/components/GuitarInputPanel.svelte
+++ b/ui/src/lib/components/GuitarInputPanel.svelte
@@ -96,14 +96,14 @@
 {#if guitar.tunerActive}
 	<!-- ============ TUNER UI ============ -->
 	<div class="guitar-panel pixel-card tuner-panel">
-		<div class="panel-header font-pixel">GUITAR INPUT</div>
+		<div class="panel-header font-ui">GUITAR INPUT</div>
 
 		{#if guitar.tunerPhase === 'noise-floor'}
 			<div class="tuner-section">
-				<div class="tuner-title font-pixel">CALIBRATING</div>
+				<div class="tuner-title font-ui">CALIBRATING</div>
 				<div class="tuner-separator"></div>
-				<div class="tuner-instruction font-pixel">Measuring noise floor...</div>
-				<div class="tuner-instruction font-pixel">Keep quiet for 3 seconds</div>
+				<div class="tuner-instruction font-ui">Measuring noise floor...</div>
+				<div class="tuner-instruction font-ui">Keep quiet for 3 seconds</div>
 				<div class="noise-progress-bar">
 					<div class="noise-progress-fill" style:width="{guitar.tunerNoiseProgress * 100}%"></div>
 				</div>
@@ -114,34 +114,34 @@
 
 		{:else if guitar.tunerPhase === 'tuning'}
 			<div class="tuner-section">
-				<div class="tuner-title font-pixel">TUNING -- String {guitar.tunerStringIndex + 1} of 6</div>
+				<div class="tuner-title font-ui">TUNING -- String {guitar.tunerStringIndex + 1} of 6</div>
 				<div class="tuner-separator"></div>
 
-				<div class="tuner-target font-pixel">
+				<div class="tuner-target font-code">
 					Pluck {tunerTarget.name} ({tunerTarget.note})
 				</div>
 
 				{#if guitar.tunerStatus === 'waiting'}
-					<div class="tuner-detected font-pixel tuner-dim">Waiting for signal...</div>
-					<div class="tuner-meter font-pixel tuner-dim">{buildMeter(0)}</div>
+					<div class="tuner-detected font-ui tuner-dim">Waiting for signal...</div>
+					<div class="tuner-meter font-code tuner-dim">{buildMeter(0)}</div>
 				{:else}
-					<div class="tuner-detected font-pixel">
+					<div class="tuner-detected font-code">
 						<span class="tuner-note">{guitar.tunerDetectedNote}</span>
 						<span class="tuner-cents" class:tuner-cents-good={Math.abs(guitar.tunerCents) <= 8} class:tuner-cents-bad={Math.abs(guitar.tunerCents) > 8}>
 							{guitar.tunerCents >= 0 ? '+' : ''}{guitar.tunerCents} cents
 						</span>
 					</div>
-					<div class="tuner-meter font-pixel" class:meter-intune={Math.abs(guitar.tunerCents) <= 8} class:meter-off={Math.abs(guitar.tunerCents) > 8}>
+					<div class="tuner-meter font-code" class:meter-intune={Math.abs(guitar.tunerCents) <= 8} class:meter-off={Math.abs(guitar.tunerCents) > 8}>
 						{buildMeter(guitar.tunerCents)}
 					</div>
 
 					{#if guitar.tunerStatus === 'sharp'}
-						<div class="tuner-advice font-pixel tuner-amber">SHARP -- tune down</div>
+						<div class="tuner-advice font-ui tuner-amber">SHARP -- tune down</div>
 					{:else if guitar.tunerStatus === 'flat'}
-						<div class="tuner-advice font-pixel tuner-amber">FLAT -- tune up</div>
+						<div class="tuner-advice font-ui tuner-amber">FLAT -- tune up</div>
 					{:else if guitar.tunerStatus === 'holding' || guitar.tunerStatus === 'in-tune'}
-						<div class="tuner-advice font-pixel tuner-cyan">IN TUNE</div>
-						<div class="tuner-hold font-pixel tuner-cyan">
+						<div class="tuner-advice font-ui tuner-cyan">IN TUNE</div>
+						<div class="tuner-hold font-code tuner-cyan">
 							{buildHoldBar(guitar.tunerHoldProgress)} holding...
 						</div>
 					{/if}
@@ -155,9 +155,9 @@
 
 		{:else if guitar.tunerPhase === 'complete'}
 			<div class="tuner-section">
-				<div class="tuner-title font-pixel tuner-cyan">TUNING COMPLETE</div>
+				<div class="tuner-title font-ui tuner-cyan">TUNING COMPLETE</div>
 				<div class="tuner-separator"></div>
-				<div class="tuner-instruction font-pixel tuner-cyan">All 6 strings tuned!</div>
+				<div class="tuner-instruction font-ui tuner-cyan">All 6 strings tuned!</div>
 				<div class="tuner-actions">
 					<button class="tuner-btn pixel-btn" onclick={() => { guitar.tunerActive = false; }}>CLOSE</button>
 				</div>
@@ -168,13 +168,13 @@
 {:else}
 	<!-- ============ NORMAL PANEL ============ -->
 	<div class="guitar-panel pixel-card">
-		<div class="panel-header font-pixel">GUITAR INPUT</div>
+		<div class="panel-header font-ui">GUITAR INPUT</div>
 
 		<!-- Audio device + channel selector -->
 		<div class="device-section">
-			<span class="device-label font-pixel">DEVICE</span>
+			<span class="device-label font-ui">DEVICE</span>
 			{#if guitar.audioDeviceError}
-				<div class="device-error font-pixel">{guitar.audioDeviceError}</div>
+				<div class="device-error font-ui">{guitar.audioDeviceError}</div>
 			{:else}
 				<div class="device-select-row">
 					<PixelSelect
@@ -186,12 +186,12 @@
 					/>
 				</div>
 				<div class="channel-header">
-					<span class="device-label font-pixel channel-label">CHANNEL</span>
-					<label class="channel-override font-pixel">
+					<span class="device-label font-ui channel-label">CHANNEL</span>
+					<label class="channel-override font-ui">
 						CH#
 						<input
 							type="number"
-							class="channel-count-input font-pixel"
+							class="channel-count-input font-code"
 							min="1"
 							max="32"
 							value={guitar.maxChannels}
@@ -206,7 +206,7 @@
 				<div class="channel-row">
 					{#each channelNumbers as ch}
 						<button
-							class="channel-btn font-pixel"
+							class="channel-btn font-code"
 							class:channel-active={guitar.selectedChannel === ch}
 							onclick={() => handleChannelChange(ch)}
 						>
@@ -221,29 +221,29 @@
 		<div class="dials-row">
 			<div class="dial-container">
 				<div class="dial dial-cyan">
-					<button class="dial-arrow dial-up font-pixel" onclick={() => guitar.setLatency(guitar.latencyMs + 1)} aria-label="Increase latency">+</button>
+					<button class="dial-arrow dial-up font-ui" onclick={() => guitar.setLatency(guitar.latencyMs + 1)} aria-label="Increase latency">+</button>
 					<span class="dial-value">{latencyDisplay}</span>
-					<button class="dial-arrow dial-down font-pixel" onclick={() => guitar.setLatency(guitar.latencyMs - 1)} aria-label="Decrease latency">-</button>
+					<button class="dial-arrow dial-down font-ui" onclick={() => guitar.setLatency(guitar.latencyMs - 1)} aria-label="Decrease latency">-</button>
 				</div>
-				<span class="dial-label font-pixel">LATENCY</span>
+				<span class="dial-label font-ui">LATENCY</span>
 			</div>
 
 			<div class="dial-container">
 				<div class="dial dial-amber">
-					<button class="dial-arrow dial-up font-pixel" onclick={() => guitar.setGain(guitar.gain + 0.05)} aria-label="Increase gain">+</button>
+					<button class="dial-arrow dial-up font-ui" onclick={() => guitar.setGain(guitar.gain + 0.05)} aria-label="Increase gain">+</button>
 					<span class="dial-value">{gainDisplay}</span>
-					<button class="dial-arrow dial-down font-pixel" onclick={() => guitar.setGain(guitar.gain - 0.05)} aria-label="Decrease gain">-</button>
+					<button class="dial-arrow dial-down font-ui" onclick={() => guitar.setGain(guitar.gain - 0.05)} aria-label="Decrease gain">-</button>
 				</div>
-				<span class="dial-label font-pixel">GAIN</span>
+				<span class="dial-label font-ui">GAIN</span>
 			</div>
 
 			<div class="dial-container">
 				<div class="dial dial-teal">
-					<button class="dial-arrow dial-up font-pixel" onclick={() => guitar.setStringConfidence(guitar.stringConfidence + 0.05)} aria-label="Increase confidence">+</button>
+					<button class="dial-arrow dial-up font-ui" onclick={() => guitar.setStringConfidence(guitar.stringConfidence + 0.05)} aria-label="Increase confidence">+</button>
 					<span class="dial-value">{confidenceDisplay}</span>
-					<button class="dial-arrow dial-down font-pixel" onclick={() => guitar.setStringConfidence(guitar.stringConfidence - 0.05)} aria-label="Decrease confidence">-</button>
+					<button class="dial-arrow dial-down font-ui" onclick={() => guitar.setStringConfidence(guitar.stringConfidence - 0.05)} aria-label="Decrease confidence">-</button>
 				</div>
-				<span class="dial-label font-pixel">CONFIDENCE</span>
+				<span class="dial-label font-ui">CONFIDENCE</span>
 			</div>
 		</div>
 
@@ -270,17 +270,17 @@
 			{guitar.calibrating ? 'CALIBRATING...' : guitar.calibrated ? 'CALIBRATED' : 'TUNE + CALIBRATE'}
 		</button>
 		{#if guitar.calibrationStatus}
-			<div class="calibration-status font-pixel" class:calibrated={guitar.calibrated}>
+			<div class="calibration-status font-ui" class:calibrated={guitar.calibrated}>
 				{guitar.calibrationStatus}
 			</div>
 		{/if}
 
 		<!-- Live detection status -->
-		<div class="detection-status font-pixel" class:detecting={guitar.detecting}>
+		<div class="detection-status font-ui" class:detecting={guitar.detecting}>
 			{detectionLine}
 		</div>
 		{#if channelMismatch}
-			<div class="channel-warning font-pixel">
+			<div class="channel-warning font-ui">
 				Using ch{guitar.activeChannel} (wanted ch{guitar.selectedChannel} — restart to change)
 			</div>
 		{/if}
@@ -382,7 +382,7 @@
 		background: var(--color-widget-bg);
 		border: 1px solid var(--color-border);
 		color: var(--color-accent-cyan);
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: var(--font-size-xs);
 		text-align: center;
 		padding: 0;

--- a/ui/src/lib/components/Knob.svelte
+++ b/ui/src/lib/components/Knob.svelte
@@ -164,11 +164,11 @@
 				<circle cx={p.x} cy={p.y} r="1.2" fill="#555577" />
 			{/each}
 		</svg>
-		<div class="knob-value font-pixel" class:dragging>{displayValue(value)}</div>
+		<div class="knob-value font-code" class:dragging>{displayValue(value)}</div>
 	</div>
 
 	{#if label}
-		<div class="knob-label font-pixel">{label}</div>
+		<div class="knob-label font-ui">{label}</div>
 	{/if}
 </div>
 

--- a/ui/src/lib/components/MidiDevices.svelte
+++ b/ui/src/lib/components/MidiDevices.svelte
@@ -79,7 +79,7 @@
 
 <!-- Input Device Section -->
 <div class="midi-section pixel-card">
-	<div class="section-header font-pixel">INPUT</div>
+	<div class="section-header font-ui">INPUT</div>
 
 	<div class="input-row">
 		<PixelSelect
@@ -100,11 +100,11 @@
 	</div>
 
 	{#if isComputerKeyboard}
-		<div class="keyboard-hint font-pixel">Z-M: C3-B3, Q-U: C4-C5</div>
+		<div class="keyboard-hint font-code">Z-M: C3-B3, Q-U: C4-C5</div>
 	{/if}
 
 	{#if midi.error}
-		<div class="error-text font-pixel">{midi.error}</div>
+		<div class="error-text font-ui">{midi.error}</div>
 	{/if}
 </div>
 
@@ -113,12 +113,12 @@
 
 <!-- Output Device Section -->
 <div class="midi-section pixel-card">
-	<div class="section-header font-pixel">OUTPUTS</div>
+	<div class="section-header font-ui">OUTPUTS</div>
 
 	<div class="output-slots">
 		{#each Array.from({ length: MAX_OUTPUT_SLOTS }, (_, i) => i) as slotIdx}
 			<div class="output-slot">
-				<span class="slot-label font-pixel">{slotLabel(slotIdx)}</span>
+				<span class="slot-label font-ui">{slotLabel(slotIdx)}</span>
 				<PixelSelect
 					options={outputOptions}
 					value={getSlotValue(slotIdx)}

--- a/ui/src/lib/components/Piano.svelte
+++ b/ui/src/lib/components/Piano.svelte
@@ -172,7 +172,7 @@
 
 <div class="piano-wrapper">
 	{#if engine.chordName}
-		<div class="chord-display font-pixel">{engine.chordName}</div>
+		<div class="chord-display font-code">{engine.chordName}</div>
 	{/if}
 	<div class="piano-container" style="--num-white-keys: {NUM_WHITE_KEYS};">
 		<!-- White keys -->
@@ -203,7 +203,7 @@
 					<span class="flash flash-{f.kind}" onanimationend={() => removeFlash(f.id)}></span>
 				{/each}
 				{#if active && ui.showNoteLabels}
-					<span class="key-label font-pixel" style:color={labelColorFor(midi, isBlackKey(midi))}>{midiToName(midi)}</span>
+					<span class="key-label font-code" style:color={labelColorFor(midi, isBlackKey(midi))}>{midiToName(midi)}</span>
 				{/if}
 			</div>
 		{/each}
@@ -237,7 +237,7 @@
 					<span class="flash flash-{f.kind}" onanimationend={() => removeFlash(f.id)}></span>
 				{/each}
 				{#if active && ui.showNoteLabels}
-					<span class="key-label font-pixel" style:color={labelColorFor(midi, isBlackKey(midi))}>{midiToName(midi)}</span>
+					<span class="key-label font-code" style:color={labelColorFor(midi, isBlackKey(midi))}>{midiToName(midi)}</span>
 				{/if}
 			</div>
 		{/each}

--- a/ui/src/lib/components/PixelSelect.svelte
+++ b/ui/src/lib/components/PixelSelect.svelte
@@ -53,7 +53,7 @@
 	tabindex="-1"
 >
 	<button
-		class="pixel-select-trigger font-pixel"
+		class="pixel-select-trigger font-ui"
 		class:open
 		class:placeholder={value === ''}
 		onclick={toggle}
@@ -66,7 +66,7 @@
 	{#if open}
 		<div class="pixel-select-dropdown">
 			<button
-				class="pixel-select-option font-pixel"
+				class="pixel-select-option font-ui"
 				class:active={value === ''}
 				onclick={() => select('')}
 				type="button"
@@ -75,7 +75,7 @@
 			</button>
 			{#each options as opt}
 				<button
-					class="pixel-select-option font-pixel"
+					class="pixel-select-option font-ui"
 					class:active={opt.value === value}
 					onclick={() => select(opt.value)}
 					type="button"

--- a/ui/src/lib/components/PresetManager.svelte
+++ b/ui/src/lib/components/PresetManager.svelte
@@ -101,19 +101,19 @@
 </script>
 
 <div class="preset-section pixel-card">
-	<div class="section-header font-pixel">PRESETS</div>
+	<div class="section-header font-ui">PRESETS</div>
 
 	{#if isLoading}
-		<div class="loading-text font-pixel">Loading...</div>
+		<div class="loading-text font-ui">Loading...</div>
 	{:else if error}
-		<div class="error-text font-pixel">{error}</div>
+		<div class="error-text font-ui">{error}</div>
 	{/if}
 
 	<!-- Preset list -->
 	<div class="preset-list">
 		{#each presets as preset}
 			<div
-				class="preset-item font-pixel"
+				class="preset-item font-ui"
 				class:preset-active={activePreset === preset.name}
 				onclick={() => handleLoadPreset(preset.name)}
 				onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') handleLoadPreset(preset.name); }}
@@ -127,7 +127,7 @@
 						<span class="builtin-badge">BUILT-IN</span>
 					{:else}
 						<button
-							class="delete-btn font-pixel"
+							class="delete-btn font-ui"
 							onclick={(e: MouseEvent) => {
 								e.stopPropagation();
 								if (confirmDelete === preset.name) {
@@ -152,7 +152,7 @@
 			<div class="save-form">
 				<input
 					type="text"
-					class="save-input font-pixel"
+					class="save-input font-ui"
 					bind:value={saveName}
 					placeholder="Preset name..."
 					onkeydown={handleSaveKeydown}

--- a/ui/src/lib/components/SettingsModal.svelte
+++ b/ui/src/lib/components/SettingsModal.svelte
@@ -79,8 +79,8 @@
 	<div class="backdrop" onclick={onBackdrop}>
 		<div class="modal pixel-card" role="dialog" aria-modal="true" aria-label="Settings">
 			<div class="modal-header">
-				<span class="title font-pixel">Settings</span>
-				<button class="close-btn pixel-btn font-pixel" onclick={close} title="Close (Esc)">
+				<span class="title font-ui">Settings</span>
+				<button class="close-btn pixel-btn font-ui" onclick={close} title="Close (Esc)">
 					×
 				</button>
 			</div>
@@ -88,10 +88,10 @@
 			<div class="modal-body">
 				<!-- Appearance section -->
 				<section class="section">
-					<h3 class="section-title font-pixel">Appearance</h3>
+					<h3 class="section-title font-ui">Appearance</h3>
 
 					<div class="row">
-						<label class="row-label font-pixel" for="settings-ui-scale">UI scale</label>
+						<label class="row-label font-ui" for="settings-ui-scale">UI scale</label>
 						<div class="row-control">
 							<input
 								id="settings-ui-scale"
@@ -104,7 +104,7 @@
 								oninput={onScaleInput}
 								onchange={onScaleCommit}
 							/>
-							<span class="value font-pixel">
+							<span class="value font-code">
 								{previewPercent}%{#if previewPercent !== currentPercent}
 									<span class="pending">*</span>
 								{/if}
@@ -113,7 +113,7 @@
 					</div>
 
 					<div class="row">
-						<label class="row-label font-pixel" for="settings-font-scale">Font size</label>
+						<label class="row-label font-ui" for="settings-font-scale">Font size</label>
 						<div class="row-control">
 							<input
 								id="settings-font-scale"
@@ -126,7 +126,7 @@
 								oninput={onFontScaleInput}
 								onchange={onFontScaleCommit}
 							/>
-							<span class="value font-pixel">
+							<span class="value font-code">
 								{previewFontPercent}%{#if previewFontPercent !== currentFontPercent}
 									<span class="pending">*</span>
 								{/if}
@@ -135,17 +135,17 @@
 					</div>
 
 					<div class="row">
-						<span class="row-label font-pixel">Note labels</span>
+						<span class="row-label font-ui">Note labels</span>
 						<div class="row-control">
 							<button
-								class="pixel-btn font-pixel"
+								class="pixel-btn font-ui"
 								class:active={ui.showNoteLabels}
 								onclick={toggleNoteLabels}
 								type="button"
 							>
 								{ui.showNoteLabels ? 'On' : 'Off'}
 							</button>
-							<span class="hint font-pixel">
+							<span class="hint font-ui">
 								{ui.showNoteLabels ? 'C4, D#5 on active keys' : 'Keys + frets only'}
 							</span>
 						</div>
@@ -154,19 +154,19 @@
 
 				<!-- Effects section -->
 				<section class="section">
-					<h3 class="section-title font-pixel">Effects</h3>
+					<h3 class="section-title font-ui">Effects</h3>
 
 					<div class="row">
-						<span class="row-label font-pixel">Visual FX</span>
+						<span class="row-label font-ui">Visual FX</span>
 						<div class="row-control">
 							<button
-								class="pixel-btn font-pixel"
+								class="pixel-btn font-ui"
 								class:active={ui.animationsEnabled}
 								onclick={toggleFx}
 							>
 								{ui.animationsEnabled ? 'On' : 'Off'}
 							</button>
-							<span class="hint font-pixel">
+							<span class="hint font-ui">
 								{ui.animationsEnabled ? 'Glows + particles' : 'Reduced motion'}
 							</span>
 						</div>

--- a/ui/src/lib/components/SignalGraphs.svelte
+++ b/ui/src/lib/components/SignalGraphs.svelte
@@ -85,11 +85,11 @@
 
 <div class="graphs-container">
 	<div class="graph-row">
-		<span class="graph-label font-pixel">AMP</span>
+		<span class="graph-label font-ui">AMP</span>
 		<canvas bind:this={ampCanvas} width={WIDTH} height={HEIGHT} class="signal-canvas"></canvas>
 		<div class="gate-controls">
 			<button
-				class="gate-btn font-pixel"
+				class="gate-btn font-ui"
 				class:gate-on={guitar.noiseGateEnabled}
 				onclick={() => { guitar.noiseGateEnabled = !guitar.noiseGateEnabled; }}
 				title="Noise Gate"

--- a/ui/src/lib/components/StatusBar.svelte
+++ b/ui/src/lib/components/StatusBar.svelte
@@ -38,7 +38,7 @@
 <div class="status-bar">
 	<!-- Transport: Start/Stop button -->
 	<button
-		class="transport-btn font-pixel"
+		class="transport-btn font-ui"
 		class:running={engine.isRunning}
 		disabled={!engine.isRunning && midi.selectedInput === null}
 		onclick={toggleTransport}
@@ -49,7 +49,7 @@
 
 	<!-- Status indicator -->
 	<span
-		class="status-indicator font-pixel"
+		class="status-indicator font-ui"
 		class:active={engine.isRunning}
 	>
 		{engine.isRunning ? 'ACTIVE' : 'STOPPED'}
@@ -61,12 +61,12 @@
 	<!-- Chord display -->
 	<div class="chord-info">
 		{#if engine.chordName}
-			<span class="chord-name font-pixel">{engine.chordName}</span>
+			<span class="chord-name font-code">{engine.chordName}</span>
 		{:else}
-			<span class="chord-name font-pixel dim">---</span>
+			<span class="chord-name font-code dim">---</span>
 		{/if}
 		{#if engine.interchangeEnabled && engine.lastBorrowedFrom}
-			<span class="borrowed-label font-pixel">from {engine.lastBorrowedFrom}</span>
+			<span class="borrowed-label font-code">from {engine.lastBorrowedFrom}</span>
 		{/if}
 	</div>
 
@@ -75,7 +75,7 @@
 
 	<!-- Settings -->
 	<button
-		class="settings-btn pixel-btn font-pixel"
+		class="settings-btn pixel-btn font-ui"
 		onclick={openSettings}
 		title="Settings"
 		aria-label="Open settings"
@@ -85,7 +85,7 @@
 
 	<!-- Brand -->
 	<img src="/logo.svg" alt="Contrapunk" class="brand-logo" />
-	<span class="brand font-pixel">Contrapunk</span>
+	<span class="brand font-ui">Contrapunk</span>
 </div>
 
 <style>

--- a/ui/src/lib/components/TransportBar.svelte
+++ b/ui/src/lib/components/TransportBar.svelte
@@ -37,7 +37,7 @@
 
 <div class="transport-bar">
 	<button
-		class="play-btn font-pixel"
+		class="play-btn font-ui"
 		class:running={transport.running}
 		onclick={togglePlay}
 		title={transport.running ? 'Stop transport' : 'Start transport'}
@@ -46,9 +46,9 @@
 	</button>
 
 	<label class="bpm-field">
-		<span class="bpm-label font-pixel">BPM</span>
+		<span class="bpm-label font-ui">BPM</span>
 		<input
-			class="bpm-input font-pixel"
+			class="bpm-input font-code"
 			type="number"
 			min="40"
 			max="240"
@@ -70,7 +70,7 @@
 	</div>
 
 	<button
-		class="click-btn font-pixel"
+		class="click-btn font-ui"
 		class:on={transport.metronomeEnabled}
 		onclick={toggleClick}
 		title={transport.metronomeEnabled ? 'Mute metronome click' : 'Enable metronome click'}

--- a/ui/src/lib/components/diary/AudioComparison.svelte
+++ b/ui/src/lib/components/diary/AudioComparison.svelte
@@ -101,7 +101,7 @@
 	}
 
 	.side-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-text-dim);
 		text-align: center;
@@ -119,7 +119,7 @@
 	}
 
 	.vs-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-text-dim);
 		letter-spacing: 2px;

--- a/ui/src/lib/components/diary/AudioPlayer.svelte
+++ b/ui/src/lib/components/diary/AudioPlayer.svelte
@@ -148,7 +148,7 @@
 		margin-top: 4px;
 	}
 	.time {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 8px;
 		color: var(--color-text-dim);
 	}

--- a/ui/src/lib/components/diary/DemoAnimation.svelte
+++ b/ui/src/lib/components/diary/DemoAnimation.svelte
@@ -188,7 +188,7 @@
 	}
 
 	.stage-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 2px;
@@ -226,7 +226,7 @@
 	}
 
 	.result-note {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 16px;
 		color: var(--color-accent-cyan);
 		letter-spacing: 1px;
@@ -283,7 +283,7 @@
 	}
 
 	.selector-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 2px;

--- a/ui/src/lib/components/diary/DiaryNav.svelte
+++ b/ui/src/lib/components/diary/DiaryNav.svelte
@@ -29,7 +29,7 @@
 		font-size: 11px;
 	}
 	.brand {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		text-decoration: none;

--- a/ui/src/lib/components/diary/RoundCard.svelte
+++ b/ui/src/lib/components/diary/RoundCard.svelte
@@ -77,7 +77,7 @@
 		align-items: center;
 		justify-content: center;
 		margin: 0 auto;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 16px;
 		color: var(--color-text-dim);
 	}
@@ -115,7 +115,7 @@
 		color: var(--color-text-primary);
 	}
 	.round-accuracy {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 16px;
 		color: var(--color-accent-cyan);
 	}

--- a/ui/src/lib/components/diary/SpectrogramComparison.svelte
+++ b/ui/src/lib/components/diary/SpectrogramComparison.svelte
@@ -119,7 +119,7 @@
 
 	.spec-loading,
 	.spec-error {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 10px;
 		color: var(--color-text-dim);
 		text-align: center;
@@ -151,7 +151,7 @@
 	}
 
 	.spec-vs {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-text-dim);
 		letter-spacing: 2px;

--- a/ui/src/lib/components/diary/SpectrogramViewer.svelte
+++ b/ui/src/lib/components/diary/SpectrogramViewer.svelte
@@ -184,7 +184,7 @@
 	}
 
 	.spectrogram-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -210,7 +210,7 @@
 		font-size: 9px;
 		color: var(--color-text-dim);
 		pointer-events: none;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		letter-spacing: 1px;
 	}
 

--- a/ui/src/lib/components/diary/StatBar.svelte
+++ b/ui/src/lib/components/diary/StatBar.svelte
@@ -30,7 +30,7 @@
 		border-right: none;
 	}
 	.stat-value {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 22px;
 		font-weight: 700;
 	}

--- a/ui/src/lib/components/diary/WaveformDisplay.svelte
+++ b/ui/src/lib/components/diary/WaveformDisplay.svelte
@@ -118,6 +118,6 @@
 		justify-content: center;
 		font-size: 10px;
 		color: var(--color-text-dim);
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 	}
 </style>

--- a/ui/src/lib/theme/pixel.css
+++ b/ui/src/lib/theme/pixel.css
@@ -12,15 +12,6 @@
 	image-rendering: crisp-edges;
 }
 
-/* === Pixel Font Rendering — disable antialiasing === */
-.font-pixel {
-	font-family: var(--font-pixel);
-	-webkit-font-smoothing: none;
-	-moz-osx-font-smoothing: unset;
-	font-smooth: never;
-	text-rendering: optimizeSpeed;
-}
-
 /* === Sharp corners everywhere — no border-radius === */
 .pixel-card {
 	border-radius: 0;
@@ -30,7 +21,7 @@
 
 /* === Pixel Button — base style === */
 .pixel-btn {
-	font-family: var(--font-pixel);
+	font-family: var(--font-ui);
 	font-size: var(--font-size-xs);
 	padding: 4px 8px;
 	background: var(--color-widget-inactive);

--- a/ui/src/lib/theme/tokens.css
+++ b/ui/src/lib/theme/tokens.css
@@ -129,8 +129,6 @@
 	--font-code: var(--font-jetbrains);
 	--font-mono: var(--font-jetbrains);
 	--font-body: var(--font-grotesk);
-	/* Legacy alias for components that still reference --font-pixel. */
-	--font-pixel: var(--font-grotesk);
 
 	/* Base font sizes scale with viewport so the UI stays proportional
 	   on any monitor. clamp(min, responsive, max) keeps them legible

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -170,7 +170,7 @@
 	{/if}
 
 	{#if initError}
-		<div class="init-error font-pixel">{initError}</div>
+		<div class="init-error font-ui">{initError}</div>
 	{/if}
 
 	<!-- Top: Status bar -->
@@ -183,14 +183,14 @@
 		<!-- Tab switcher -->
 		<div class="tab-strip">
 			<button
-				class="tab-btn font-pixel"
+				class="tab-btn font-ui"
 				class:active={ui.activeTab === 'play'}
 				onclick={() => (ui.activeTab = 'play')}
 			>
 				Play
 			</button>
 			<button
-				class="tab-btn font-pixel"
+				class="tab-btn font-ui"
 				class:active={ui.activeTab === 'chain'}
 				onclick={() => (ui.activeTab = 'chain')}
 			>
@@ -235,7 +235,7 @@
 			</div>
 		{/if}
 	{:else if !initError}
-		<div class="init-loading font-pixel">Initializing engine...</div>
+		<div class="init-loading font-ui">Initializing engine...</div>
 	{/if}
 </div>
 

--- a/ui/src/routes/diary/+page.svelte
+++ b/ui/src/routes/diary/+page.svelte
@@ -81,7 +81,7 @@
 		text-align: center;
 	}
 	.tagline-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-magenta);
 		letter-spacing: 4px;
@@ -110,7 +110,7 @@
 		padding: 32px 24px;
 	}
 	.section-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -140,7 +140,7 @@
 		box-shadow: 0 0 20px rgba(51, 221, 255, 0.07);
 	}
 	.chapter-phase {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 9px;
 		color: var(--color-text-dim);
 	}

--- a/ui/src/routes/diary/machine-learning/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/+page.svelte
@@ -190,7 +190,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -227,7 +227,7 @@
 	.step:first-child { border-radius: 4px 0 0 4px; }
 	.step:last-child { border-radius: 0 4px 4px 0; }
 	.step-num {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 18px;
 		color: var(--color-accent-cyan);
 	}
@@ -265,7 +265,7 @@
 		background: var(--color-widget-bg);
 	}
 	.tool-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 11px;
 	}
 	.tool-desc {
@@ -303,7 +303,7 @@
 		flex: 1;
 	}
 	.pivot-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-amber, #ffaa33);
 		letter-spacing: 2px;

--- a/ui/src/routes/diary/machine-learning/playground/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/playground/+page.svelte
@@ -514,7 +514,7 @@
 	}
 
 	.label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -598,7 +598,7 @@
 	}
 
 	.input-title {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 12px;
 		color: var(--color-text-primary);
 	}
@@ -613,7 +613,7 @@
 		font-size: 10px;
 		color: var(--color-accent-teal);
 		margin-top: 8px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -623,7 +623,7 @@
 		position: absolute;
 		top: 8px;
 		right: 8px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -685,7 +685,7 @@
 	}
 
 	.step-num {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 12px;
 		color: var(--color-text-dim);
 	}
@@ -746,7 +746,7 @@
 		gap: 16px;
 		font-size: 11px;
 		color: var(--color-text-dim);
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		margin-bottom: 8px;
 	}
 
@@ -778,7 +778,7 @@
 		background: var(--color-accent-cyan);
 		color: var(--color-bg-deep);
 		border: none;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 13px;
 		letter-spacing: 1px;
 		cursor: pointer;
@@ -816,7 +816,7 @@
 	}
 
 	.result-rank {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 12px;
 		color: var(--color-text-dim);
 		width: 24px;
@@ -830,7 +830,7 @@
 		font-size: 13px;
 		color: var(--color-text-primary);
 		width: 120px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 	}
 
 	.result-bar-wrap {
@@ -853,7 +853,7 @@
 	}
 
 	.result-pct {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 11px;
 		color: var(--color-text-secondary);
 		width: 48px;
@@ -929,7 +929,7 @@
 	}
 
 	.explainer-num {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 18px;
 		color: var(--color-accent-cyan);
 		margin-bottom: 4px;
@@ -978,7 +978,7 @@
 	.tech-val {
 		font-size: 12px;
 		color: var(--color-text-primary);
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 	}
 
 	/* ======================================================================

--- a/ui/src/routes/diary/machine-learning/round-1/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/round-1/+page.svelte
@@ -758,7 +758,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.round-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 3px;
@@ -791,7 +791,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.station-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -876,7 +876,7 @@
 		align-items: center;
 	}
 	.selector-acc {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 15px;
 	}
 	.selector-meta {
@@ -896,7 +896,7 @@
 		margin-bottom: 20px;
 	}
 	.model-detail-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-teal);
 		letter-spacing: 2px;
@@ -927,7 +927,7 @@
 		justify-content: center;
 		background: var(--color-bg-panel);
 		border: 1px solid var(--color-border);
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 10px;
 		color: var(--color-accent-cyan);
 		margin-top: 2px;
@@ -956,7 +956,7 @@
 		margin: 0;
 	}
 	.io-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		letter-spacing: 2px;
 		margin-bottom: 6px;
@@ -971,7 +971,7 @@
 		margin-top: 16px;
 	}
 	.insight-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-amber);
 		letter-spacing: 2px;
@@ -1008,7 +1008,7 @@
 	}
 	.tab-acc {
 		display: block;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 14px;
 		margin-top: 4px;
 	}
@@ -1051,7 +1051,7 @@
 	}
 	.bar-value {
 		width: 50px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 11px;
 		text-align: right;
 		flex-shrink: 0;
@@ -1080,7 +1080,7 @@
 	}
 	.finding-icon {
 		flex-shrink: 0;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		width: 24px;
 		height: 24px;
@@ -1127,7 +1127,7 @@
 		margin-top: 24px;
 	}
 	.hear-heading {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-teal);
 		letter-spacing: 2px;
@@ -1152,7 +1152,7 @@
 	}
 	.next-link a {
 		display: inline-block;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-cyan);
 		text-decoration: none;

--- a/ui/src/routes/diary/machine-learning/round-2/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/round-2/+page.svelte
@@ -439,7 +439,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.round-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 3px;
@@ -492,14 +492,14 @@
 		align-items: center;
 	}
 	.comp-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
 		margin-bottom: 4px;
 	}
 	.comp-value {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 22px;
 		color: var(--color-accent-cyan);
 	}
@@ -515,7 +515,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.station-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -548,7 +548,7 @@
 	}
 	.process-steps li::marker {
 		color: var(--color-accent-cyan);
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 10px;
 	}
 
@@ -576,7 +576,7 @@
 	}
 	.tab-acc {
 		display: block;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 14px;
 		margin-top: 4px;
 	}
@@ -592,7 +592,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.mc-header .mc-col {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -669,7 +669,7 @@
 	}
 	.bar-value {
 		width: 50px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 11px;
 		text-align: right;
 		flex-shrink: 0;
@@ -683,7 +683,7 @@
 		margin-bottom: 16px;
 	}
 	.viz-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		text-transform: uppercase;
@@ -712,7 +712,7 @@
 		margin-top: 16px;
 	}
 	.insight-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-cyan);
 		letter-spacing: 2px;
@@ -748,7 +748,7 @@
 	}
 	.finding-icon {
 		flex-shrink: 0;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 10px;
 		width: 24px;
 		height: 24px;
@@ -792,7 +792,7 @@
 		margin-top: 16px;
 	}
 	.takeaway-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-teal);
 		letter-spacing: 2px;
@@ -813,7 +813,7 @@
 		margin-top: 16px;
 	}
 	.nav-link {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-cyan);
 		text-decoration: none;

--- a/ui/src/routes/diary/machine-learning/round-3/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/round-3/+page.svelte
@@ -385,7 +385,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.round-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 3px;
@@ -438,14 +438,14 @@
 		align-items: center;
 	}
 	.comp-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
 		margin-bottom: 4px;
 	}
 	.comp-value {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 22px;
 		color: var(--color-accent-cyan);
 	}
@@ -469,7 +469,7 @@
 		text-align: center;
 	}
 	.removal-num {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 28px;
 		color: var(--color-accent-magenta);
 	}
@@ -492,7 +492,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.station-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -539,7 +539,7 @@
 	}
 	.tab-acc {
 		display: block;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 14px;
 		margin-top: 4px;
 	}
@@ -555,7 +555,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.mc-header .mc-col {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -621,7 +621,7 @@
 	}
 	.bar-value {
 		width: 50px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 11px;
 		text-align: right;
 		flex-shrink: 0;
@@ -635,7 +635,7 @@
 		margin-bottom: 16px;
 	}
 	.viz-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		text-transform: uppercase;
@@ -677,7 +677,7 @@
 	}
 	.finding-icon {
 		flex-shrink: 0;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 10px;
 		width: 24px;
 		height: 24px;
@@ -720,7 +720,7 @@
 		margin-top: 16px;
 	}
 	.nav-link {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-cyan);
 		text-decoration: none;

--- a/ui/src/routes/diary/machine-learning/round-4/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/round-4/+page.svelte
@@ -407,7 +407,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.round-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 3px;
@@ -460,14 +460,14 @@
 		align-items: center;
 	}
 	.comp-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
 		margin-bottom: 4px;
 	}
 	.comp-value {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 22px;
 		color: var(--color-accent-cyan);
 	}
@@ -491,7 +491,7 @@
 		text-align: center;
 	}
 	.feature-num {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 28px;
 		color: var(--color-accent-cyan);
 	}
@@ -514,7 +514,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.station-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -561,7 +561,7 @@
 	}
 	.tab-acc {
 		display: block;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 14px;
 		margin-top: 4px;
 	}
@@ -577,7 +577,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.mc-header .mc-col {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -654,7 +654,7 @@
 	}
 	.bar-value {
 		width: 50px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 11px;
 		text-align: right;
 		flex-shrink: 0;
@@ -668,7 +668,7 @@
 		margin-bottom: 16px;
 	}
 	.viz-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		text-transform: uppercase;
@@ -710,7 +710,7 @@
 	}
 	.finding-icon {
 		flex-shrink: 0;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 10px;
 		width: 24px;
 		height: 24px;
@@ -753,7 +753,7 @@
 		margin-top: 16px;
 	}
 	.nav-link {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-cyan);
 		text-decoration: none;

--- a/ui/src/routes/diary/machine-learning/round-5/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/round-5/+page.svelte
@@ -477,7 +477,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.round-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 3px;
@@ -530,14 +530,14 @@
 		align-items: center;
 	}
 	.comp-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
 		margin-bottom: 4px;
 	}
 	.comp-value {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 22px;
 		color: var(--color-accent-cyan);
 	}
@@ -560,7 +560,7 @@
 		padding: 16px;
 	}
 	.aug-name {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 11px;
 		color: var(--color-accent-cyan);
 		letter-spacing: 1px;
@@ -594,7 +594,7 @@
 		text-align: center;
 	}
 	.ds-value {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 22px;
 		color: var(--color-accent-cyan);
 	}
@@ -604,7 +604,7 @@
 		margin-top: 4px;
 	}
 	.ds-arrow {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 16px;
 		color: var(--color-text-dim);
 		padding: 0 16px;
@@ -620,7 +620,7 @@
 		margin-top: 16px;
 	}
 	.insight-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-amber);
 		letter-spacing: 2px;
@@ -642,7 +642,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.station-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-magenta);
 		letter-spacing: 2px;
@@ -689,7 +689,7 @@
 	}
 	.tab-acc {
 		display: block;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 14px;
 		margin-top: 4px;
 	}
@@ -705,7 +705,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.mc-header .mc-col {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -782,7 +782,7 @@
 	}
 	.bar-value {
 		width: 50px;
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		font-size: 11px;
 		text-align: right;
 		flex-shrink: 0;
@@ -796,7 +796,7 @@
 		margin-bottom: 16px;
 	}
 	.viz-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		text-transform: uppercase;
@@ -838,7 +838,7 @@
 	}
 	.finding-icon {
 		flex-shrink: 0;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 10px;
 		width: 24px;
 		height: 24px;
@@ -899,7 +899,7 @@
 		margin-top: 16px;
 	}
 	.nav-link {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-cyan);
 		text-decoration: none;

--- a/ui/src/routes/diary/machine-learning/the-pivot/+page.svelte
+++ b/ui/src/routes/diary/machine-learning/the-pivot/+page.svelte
@@ -367,7 +367,7 @@
 		border-bottom: 1px solid var(--color-border);
 	}
 	.section-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-amber, #ffaa33);
 		letter-spacing: 3px;
@@ -398,7 +398,7 @@
 		border-bottom: none;
 	}
 	.station-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-xs);
 		color: var(--color-accent-amber, #ffaa33);
 		letter-spacing: 2px;
@@ -444,7 +444,7 @@
 		font-size: 13px;
 	}
 	.journey-table th {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -460,12 +460,12 @@
 		color: var(--color-text-secondary);
 	}
 	.journey-table .round-num {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		color: var(--color-accent-cyan);
 		width: 48px;
 	}
 	.journey-table .acc {
-		font-family: var(--font-pixel);
+		font-family: var(--font-code);
 		color: var(--color-accent-cyan);
 	}
 	.journey-table .acc.best {
@@ -499,7 +499,7 @@
 	}
 	.finding-icon {
 		flex-shrink: 0;
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 10px;
 		width: 24px;
 		height: 24px;
@@ -521,7 +521,7 @@
 		text-align: center;
 	}
 	.equation-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		letter-spacing: 2px;
@@ -568,7 +568,7 @@
 		font-size: 13px;
 	}
 	.compare-table th {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		letter-spacing: 1px;
@@ -611,7 +611,7 @@
 		margin: 20px 0;
 	}
 	.arch-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 9px;
 		color: var(--color-text-dim);
 		letter-spacing: 2px;
@@ -657,7 +657,7 @@
 		border: 1px dashed var(--color-border);
 	}
 	.arch-branch-label {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: 8px;
 		letter-spacing: 1px;
 	}
@@ -703,7 +703,7 @@
 		margin-top: 16px;
 	}
 	.nav-link {
-		font-family: var(--font-pixel);
+		font-family: var(--font-ui);
 		font-size: var(--font-size-sm);
 		color: var(--color-accent-cyan);
 		text-decoration: none;


### PR DESCRIPTION
Closes #51.

## Summary

- 250 `.font-pixel` uses audited across 33 .svelte files and re-classified by semantic role
- **183 sites → `.font-ui`** (buttons/labels/chrome): no visible change
- **65 sites → `.font-code`** (note names, BPM, stats, plugin IDs, technical readouts): now render JetBrains Mono instead of Space Grotesk — **this is the intended visible fix**
- 2 mixed-role wrappers split into per-child classes (`ChainPanel.plugin-body`, `ClapPluginPicker.plugin-row`)
- Dead code removed: legacy `.font-pixel` rule in `pixel.css`, `--font-pixel` var in `tokens.css`
- Retro pixel-rendering aesthetic preserved: `-webkit-font-smoothing: none` + `text-rendering: optimizeSpeed` moved from the old `.font-pixel` onto `.font-ui` and `.font-code`
- Net diff: +275 / -269 across 36 files. svelte-check: 0 errors, 23 pre-existing warnings unchanged.

## Visible behavior changes

- **Technical readouts** (note names like `C4`, BPM numerics, chord names like `Cmaj7`, plugin IDs, ML diary stats): now render JetBrains Mono. Intended — that's the whole point of `--font-code`.
- **UI chrome / labels / buttons**: unchanged (was already rendering Space Grotesk via the alias).
- **Prose / headings**: unchanged (weren't using `.font-pixel` to begin with).

## Test plan

- [ ] Boot the app, eyeball the Piano / Fretboard note-name labels, StatusBar BPM + chord display, ActiveNotes panel — should be JetBrains Mono, clearly distinguishable from the UI chrome
- [ ] Chrome (buttons, panel headers, dropdown items, form inputs) should still look exactly like before — Space Grotesk with the retro pixel-rendering
- [ ] Diary pages (e.g. `/diary/machine-learning/round-5`): headings / prose unchanged, stat numerics now mono
- [ ] Mixed-role wrappers: `ChainPanel` plugin-body shows "Type: CLAP" in ui font, plugin-id value in mono. `ClapPluginPicker` plugin row shows name/vendor in ui font, path in mono.
- [ ] `prefers-reduced-motion`, `ui-scale`, `font-scale` sliders still work

## Audit artifacts

Classification audit (not committed to repo, but on the branch author's local): `.planning/font-pixel-audit/{audit.json,summary.md,audit.html}` — one row per occurrence with its target class and reason.