### PR TITLE
feat(engine): per-voice output routing infrastructure (#57)

### DIFF
--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -22,7 +22,7 @@ use contrapunk::midi::output::OutputRouter;
 use contrapunk::synth::SynthEvent;
 
 use crate::guitar_bridge::GuitarBridge;
-use crate::state::AppState;
+use crate::state::{AppState, VoiceOutputTarget};
 
 /// Virtual input sentinels — must match the values in MidiDevices.svelte.
 const VIRTUAL_COMPUTER_KEYBOARD: usize = 999_998;
@@ -212,6 +212,10 @@ pub fn start_routing(
     // events into the built-in synth alongside external MIDI output.
     let synth_tx = state.synth_tx.clone();
 
+    // Share the per-voice output routing table with the router thread.
+    // Lock-read at each note dispatch to honor live UI changes.
+    let voice_outputs = Arc::clone(&state.voice_outputs);
+
     // Spawn router thread
     thread::spawn(move || {
         if let Err(e) = run_tauri_router(
@@ -234,6 +238,7 @@ pub fn start_routing(
             detune,
             panic_flag,
             synth_tx,
+            voice_outputs,
         ) {
             eprintln!("[tauri-router] Error: {}", e);
         }
@@ -319,6 +324,7 @@ fn run_tauri_router(
     detune_cents: Arc<AtomicI32>,
     panic_pending: Arc<std::sync::atomic::AtomicBool>,
     synth_tx: mpsc::Sender<SynthEvent>,
+    voice_outputs: Arc<Mutex<Vec<VoiceOutputTarget>>>,
 ) -> anyhow::Result<()> {
     let (
         key,
@@ -454,6 +460,7 @@ fn run_tauri_router(
                     &chord_name,
                     routing_mode,
                     &synth_tx,
+                    &voice_outputs,
                 );
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
@@ -559,6 +566,7 @@ fn process_midi_message(
     chord_name: &Arc<Mutex<String>>,
     routing_mode: contrapunk::harmony::RoutingMode,
     synth_tx: &mpsc::Sender<SynthEvent>,
+    voice_outputs: &Arc<Mutex<Vec<VoiceOutputTarget>>>,
 ) {
     let msg = match MidiMessage::try_from(bytes) {
         Ok(m) => m,
@@ -583,6 +591,7 @@ fn process_midi_message(
                     chord_name,
                     routing_mode,
                     synth_tx,
+                    voice_outputs,
                 );
             } else {
                 handle_note_on(
@@ -597,6 +606,7 @@ fn process_midi_message(
                     chord_name,
                     routing_mode,
                     synth_tx,
+                    voice_outputs,
                 );
             }
         }
@@ -613,6 +623,7 @@ fn process_midi_message(
                 chord_name,
                 routing_mode,
                 synth_tx,
+                voice_outputs,
             );
         }
         _ => {
@@ -634,17 +645,31 @@ fn handle_note_on(
     chord_name: &Arc<Mutex<String>>,
     routing_mode: contrapunk::harmony::RoutingMode,
     synth_tx: &mpsc::Sender<SynthEvent>,
+    voice_outputs: &Arc<Mutex<Vec<VoiceOutputTarget>>>,
 ) {
     let notes = engine.harmonize_note_on(note);
     let num_outputs = output.connection_count();
 
-    // Fan each harmony voice into the built-in synth so speakers play
-    // the same notes that go out the external MIDI ports.
-    for &n in notes.iter() {
-        let _ = synth_tx.send(SynthEvent::NoteOn {
-            note: u8::from(n),
-            velocity: u8::from(velocity),
-        });
+    // Snapshot voice routing once per note event — clone is cheap
+    // (8-element Vec of Copy enums) and avoids lock contention during
+    // dispatch.
+    let voice_targets: Vec<VoiceOutputTarget> = voice_outputs
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let target_for =
+        |i: usize| -> VoiceOutputTarget { voice_targets.get(i).copied().unwrap_or_default() };
+
+    // Fan each voice into the built-in synth, gated by voice_outputs.
+    // UseDefault preserves legacy behavior (every voice goes to synth).
+    for (i, &n) in notes.iter().enumerate() {
+        let t = target_for(i);
+        if matches!(t, VoiceOutputTarget::Synth | VoiceOutputTarget::UseDefault) {
+            let _ = synth_tx.send(SynthEvent::NoteOn {
+                note: u8::from(n),
+                velocity: u8::from(velocity),
+            });
+        }
     }
 
     // Update shared state — recover from poisoned mutexes rather than panic.
@@ -679,31 +704,15 @@ fn handle_note_on(
         }
     }
 
-    // Send notes to outputs based on routing mode
+    // Send notes to outputs, per-voice:
+    //   Synth | Off       -> no MIDI (handled above or silent)
+    //   MidiPort { port } -> send directly to that port
+    //   UseDefault        -> fall back to global routing_mode behavior
     let port_map = engine.last_port_map();
-    match routing_mode {
-        contrapunk::harmony::RoutingMode::ChannelBased => {
-            // MPE: all voices on port 0, each on its own MIDI channel.
-            for (i, &n) in notes.iter().enumerate() {
-                let voice_channel = match i + 1 {
-                    1 => Channel::Ch2,
-                    2 => Channel::Ch3,
-                    3 => Channel::Ch4,
-                    4 => Channel::Ch5,
-                    5 => Channel::Ch6,
-                    6 => Channel::Ch7,
-                    _ => Channel::Ch8,
-                };
-                let msg = MidiMessage::NoteOn(voice_channel, n, velocity);
-                let mut buf = vec![0u8; msg.bytes_size()];
-                let _ = msg.copy_to_slice(&mut buf);
-                let _ = output.send_to_first(&buf);
-                let _ = i;
-            }
-        }
-        contrapunk::harmony::RoutingMode::PortBased => {
-            for (i, &n) in notes.iter().enumerate() {
-                let port = if i < port_map.len() { port_map[i] } else { i };
+    for (i, &n) in notes.iter().enumerate() {
+        match target_for(i) {
+            VoiceOutputTarget::Synth | VoiceOutputTarget::Off => {}
+            VoiceOutputTarget::MidiPort { port } => {
                 if port >= num_outputs {
                     continue;
                 }
@@ -712,6 +721,34 @@ fn handle_note_on(
                 let _ = msg.copy_to_slice(&mut buf);
                 let _ = output.send_to_port(port, &buf);
             }
+            VoiceOutputTarget::UseDefault => match routing_mode {
+                contrapunk::harmony::RoutingMode::ChannelBased => {
+                    // MPE: all voices on port 0, each on its own MIDI channel.
+                    let voice_channel = match i + 1 {
+                        1 => Channel::Ch2,
+                        2 => Channel::Ch3,
+                        3 => Channel::Ch4,
+                        4 => Channel::Ch5,
+                        5 => Channel::Ch6,
+                        6 => Channel::Ch7,
+                        _ => Channel::Ch8,
+                    };
+                    let msg = MidiMessage::NoteOn(voice_channel, n, velocity);
+                    let mut buf = vec![0u8; msg.bytes_size()];
+                    let _ = msg.copy_to_slice(&mut buf);
+                    let _ = output.send_to_first(&buf);
+                }
+                contrapunk::harmony::RoutingMode::PortBased => {
+                    let port = if i < port_map.len() { port_map[i] } else { i };
+                    if port >= num_outputs {
+                        continue;
+                    }
+                    let msg = MidiMessage::NoteOn(channel, n, velocity);
+                    let mut buf = vec![0u8; msg.bytes_size()];
+                    let _ = msg.copy_to_slice(&mut buf);
+                    let _ = output.send_to_port(port, &buf);
+                }
+            },
         }
     }
 }
@@ -729,14 +766,27 @@ fn handle_note_off(
     _chord_name: &Arc<Mutex<String>>,
     routing_mode: contrapunk::harmony::RoutingMode,
     synth_tx: &mpsc::Sender<SynthEvent>,
+    voice_outputs: &Arc<Mutex<Vec<VoiceOutputTarget>>>,
 ) {
     let notes = engine.harmonize_note_off(note);
     let num_outputs = output.connection_count();
 
-    // Fan releases into the built-in synth so its voices finish with
-    // the same timing as the external MIDI note-offs.
-    for &n in notes.iter() {
-        let _ = synth_tx.send(SynthEvent::NoteOff { note: u8::from(n) });
+    // Snapshot voice routing — same pattern as handle_note_on.
+    let voice_targets: Vec<VoiceOutputTarget> = voice_outputs
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let target_for =
+        |i: usize| -> VoiceOutputTarget { voice_targets.get(i).copied().unwrap_or_default() };
+
+    // Fan releases into the built-in synth only for voices whose target
+    // includes it. Note-offs must match the note-ons; see handle_note_on
+    // for the same gate.
+    for (i, &n) in notes.iter().enumerate() {
+        let t = target_for(i);
+        if matches!(t, VoiceOutputTarget::Synth | VoiceOutputTarget::UseDefault) {
+            let _ = synth_tx.send(SynthEvent::NoteOff { note: u8::from(n) });
+        }
     }
 
     {
@@ -752,30 +802,12 @@ fn handle_note_off(
         }
     }
 
-    // Send note-offs based on routing mode
+    // Send note-offs per voice, mirroring handle_note_on's dispatch.
     let port_map = engine.last_port_map();
-    match routing_mode {
-        contrapunk::harmony::RoutingMode::ChannelBased => {
-            for (i, &n) in notes.iter().enumerate() {
-                let voice_channel = match i + 1 {
-                    1 => Channel::Ch2,
-                    2 => Channel::Ch3,
-                    3 => Channel::Ch4,
-                    4 => Channel::Ch5,
-                    5 => Channel::Ch6,
-                    6 => Channel::Ch7,
-                    _ => Channel::Ch8,
-                };
-                let msg = MidiMessage::NoteOff(voice_channel, n, velocity);
-                let mut buf = vec![0u8; msg.bytes_size()];
-                let _ = msg.copy_to_slice(&mut buf);
-                let _ = output.send_to_first(&buf);
-                let _ = i;
-            }
-        }
-        contrapunk::harmony::RoutingMode::PortBased => {
-            for (i, &n) in notes.iter().enumerate() {
-                let port = if i < port_map.len() { port_map[i] } else { i };
+    for (i, &n) in notes.iter().enumerate() {
+        match target_for(i) {
+            VoiceOutputTarget::Synth | VoiceOutputTarget::Off => {}
+            VoiceOutputTarget::MidiPort { port } => {
                 if port >= num_outputs {
                     continue;
                 }
@@ -784,6 +816,33 @@ fn handle_note_off(
                 let _ = msg.copy_to_slice(&mut buf);
                 let _ = output.send_to_port(port, &buf);
             }
+            VoiceOutputTarget::UseDefault => match routing_mode {
+                contrapunk::harmony::RoutingMode::ChannelBased => {
+                    let voice_channel = match i + 1 {
+                        1 => Channel::Ch2,
+                        2 => Channel::Ch3,
+                        3 => Channel::Ch4,
+                        4 => Channel::Ch5,
+                        5 => Channel::Ch6,
+                        6 => Channel::Ch7,
+                        _ => Channel::Ch8,
+                    };
+                    let msg = MidiMessage::NoteOff(voice_channel, n, velocity);
+                    let mut buf = vec![0u8; msg.bytes_size()];
+                    let _ = msg.copy_to_slice(&mut buf);
+                    let _ = output.send_to_first(&buf);
+                }
+                contrapunk::harmony::RoutingMode::PortBased => {
+                    let port = if i < port_map.len() { port_map[i] } else { i };
+                    if port >= num_outputs {
+                        continue;
+                    }
+                    let msg = MidiMessage::NoteOff(channel, n, velocity);
+                    let mut buf = vec![0u8; msg.bytes_size()];
+                    let _ = msg.copy_to_slice(&mut buf);
+                    let _ = output.send_to_port(port, &buf);
+                }
+            },
         }
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,5 +11,6 @@ pub mod harmony;
 pub mod midi;
 pub mod plugins;
 pub mod presets;
+pub mod routing;
 pub mod synth;
 pub mod transport;

--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -1,0 +1,80 @@
+//! Tauri commands for per-voice output routing.
+//!
+//! Exposes the `voice_outputs` table from `AppState` so the UI can
+//! configure where each voice sends notes: internal synth, a specific
+//! external MIDI port, off, or defer to the global routing mode.
+
+use tauri::State;
+
+use crate::state::{AppState, VoiceOutputTarget, MAX_VOICES};
+
+/// Set the output destination for a single voice by index (0-based).
+#[tauri::command]
+pub fn set_voice_output(
+    voice_idx: usize,
+    target: VoiceOutputTarget,
+    state: State<AppState>,
+) -> Result<(), String> {
+    if voice_idx >= MAX_VOICES {
+        return Err(format!(
+            "voice_idx {} out of range (max {})",
+            voice_idx,
+            MAX_VOICES - 1
+        ));
+    }
+    let mut outputs = state.voice_outputs.lock().map_err(|e| e.to_string())?;
+    outputs[voice_idx] = target;
+    Ok(())
+}
+
+/// Return the current voice-output routing table as a Vec of length
+/// MAX_VOICES. Each entry is the destination for that voice index.
+#[tauri::command]
+pub fn get_voice_outputs(state: State<AppState>) -> Result<Vec<VoiceOutputTarget>, String> {
+    let outputs = state.voice_outputs.lock().map_err(|e| e.to_string())?;
+    Ok(outputs.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn voice_output_target_roundtrips_through_serde() {
+        let cases = [
+            VoiceOutputTarget::UseDefault,
+            VoiceOutputTarget::Synth,
+            VoiceOutputTarget::MidiPort { port: 3 },
+            VoiceOutputTarget::Off,
+        ];
+        for t in cases {
+            let json = serde_json::to_string(&t).unwrap();
+            let back: VoiceOutputTarget = serde_json::from_str(&json).unwrap();
+            assert_eq!(t, back, "failed roundtrip: {json}");
+        }
+    }
+
+    #[test]
+    fn voice_output_target_json_shape_is_tagged() {
+        // Frontend contract: `{ kind: "midi_port", port: 2 }` and similar.
+        // Lock the shape so type changes break the test instead of silently
+        // breaking the TS adapter.
+        assert_eq!(
+            serde_json::to_string(&VoiceOutputTarget::UseDefault).unwrap(),
+            r#"{"kind":"use_default"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&VoiceOutputTarget::Synth).unwrap(),
+            r#"{"kind":"synth"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&VoiceOutputTarget::MidiPort { port: 2 }).unwrap(),
+            r#"{"kind":"midi_port","port":2}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&VoiceOutputTarget::Off).unwrap(),
+            r#"{"kind":"off"}"#
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -84,6 +84,9 @@ fn main() {
             commands::engine::get_note_state,
             commands::engine::inject_note_on,
             commands::engine::inject_note_off,
+            // Per-voice output routing
+            commands::routing::set_voice_output,
+            commands::routing::get_voice_outputs,
             // Guitar audio input
             commands::guitar::set_guitar_device,
             commands::guitar::set_guitar_config,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,6 +8,8 @@ use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
+use serde::{Deserialize, Serialize};
+
 use contrapunk::audio::guitar_input::GuitarInputConfig;
 use contrapunk::chain::ChainCommander;
 use contrapunk::fx::{DelayParams, ReverbParams};
@@ -15,6 +17,34 @@ use contrapunk::harmony::{HarmonyEngine, HarmonyMode, Key, RoutingMode};
 use contrapunk::preset::PresetManager;
 use contrapunk::synth::{SynthEvent, SynthParams};
 use contrapunk::transport::Transport;
+
+/// Maximum number of voices the app exposes. Mirrors the 8 voice slots
+/// in the output panel UI; `voice_outputs` is sized to this. The engine
+/// itself accepts any voice_count up to this value.
+pub const MAX_VOICES: usize = 8;
+
+/// Per-voice output destination. Each engine-emitted voice (by index
+/// 0..voice_count-1) can be routed independently.
+///
+/// The default — `UseDefault` — preserves the legacy behavior where
+/// every voice fans out to both the internal synth AND to external
+/// MIDI ports via the global `routing_mode`. Explicitly setting a
+/// voice's target overrides that for just that voice, so e.g. voice 0
+/// can go to `MidiPort { port: 0 }` (external synth) while voices 1-3
+/// stay on `Synth` (internal synth), with no double-tracking.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VoiceOutputTarget {
+    /// Defer to the global `routing_mode` (legacy behavior: synth + MIDI).
+    #[default]
+    UseDefault,
+    /// Send to the internal synth only. Skip external MIDI for this voice.
+    Synth,
+    /// Send to a specific external MIDI port only. Skip the internal synth.
+    MidiPort { port: usize },
+    /// Skip both synth and external MIDI. Voice is silent.
+    Off,
+}
 
 /// Application state managed by Tauri.
 ///
@@ -111,6 +141,13 @@ pub struct AppState {
     /// runtime (add/remove blocks). Populated by the audio-clock
     /// setup hook after the Chain is constructed.
     pub chain_commander: Mutex<Option<Arc<ChainCommander>>>,
+
+    /// Per-voice output routing table, indexed 0..MAX_VOICES.
+    /// Router thread reads this on every note to decide whether each
+    /// voice goes to the internal synth, to a specific MIDI port, or
+    /// nowhere. Default all `UseDefault` preserves the legacy fan-out
+    /// behavior for existing users until the UI sets explicit values.
+    pub voice_outputs: Arc<Mutex<Vec<VoiceOutputTarget>>>,
 }
 
 impl Default for AppState {
@@ -144,6 +181,7 @@ impl Default for AppState {
             reverb_params: Arc::new(ReverbParams::default()),
             delay_params: Arc::new(DelayParams::default()),
             chain_commander: Mutex::new(None),
+            voice_outputs: Arc::new(Mutex::new(vec![VoiceOutputTarget::default(); MAX_VOICES])),
         }
     }
 }

--- a/ui/src/lib/adapter/plugin.ts
+++ b/ui/src/lib/adapter/plugin.ts
@@ -14,8 +14,10 @@ import type {
 	MidiDevice,
 	NoteState,
 	Preset,
-	TransportState
+	TransportState,
+	VoiceOutputTarget
 } from './types';
+import { MAX_VOICES } from './types';
 
 declare global {
 	interface Window {
@@ -152,6 +154,21 @@ export class PluginAdapter implements ContrapunkAdapter {
 
 	async startRouting(_inputIdx: number, _outputIndices: number[]): Promise<void> {}
 	async stopRouting(): Promise<void> {}
+
+	// Per-voice output routing — the plugin host handles MIDI routing
+	// outside the UI, so these are no-ops that just track the user's
+	// selection in memory for UI restoration.
+	private _voiceOutputs: VoiceOutputTarget[] = Array.from(
+		{ length: MAX_VOICES },
+		() => ({ kind: 'use_default' })
+	);
+	async setVoiceOutput(voiceIdx: number, target: VoiceOutputTarget): Promise<void> {
+		if (voiceIdx < 0 || voiceIdx >= MAX_VOICES) return;
+		this._voiceOutputs[voiceIdx] = target;
+	}
+	async getVoiceOutputs(): Promise<VoiceOutputTarget[]> {
+		return this._voiceOutputs.slice();
+	}
 
 	// -- Real-time state --
 

--- a/ui/src/lib/adapter/tauri.ts
+++ b/ui/src/lib/adapter/tauri.ts
@@ -22,7 +22,8 @@ import type {
 	Preset,
 	ReverbState,
 	SynthState,
-	TransportState
+	TransportState,
+	VoiceOutputTarget
 } from './types';
 
 /**
@@ -275,6 +276,22 @@ export class TauriAdapter implements ContrapunkAdapter {
 			guitar.velocity = 0;
 		} catch (e) {
 			throw new Error(`Failed to stop routing: ${e}`);
+		}
+	}
+
+	async setVoiceOutput(voiceIdx: number, target: VoiceOutputTarget): Promise<void> {
+		try {
+			await invoke('set_voice_output', { voiceIdx, target });
+		} catch (e) {
+			throw new Error(`Failed to set voice output: ${e}`);
+		}
+	}
+
+	async getVoiceOutputs(): Promise<VoiceOutputTarget[]> {
+		try {
+			return (await invoke('get_voice_outputs')) as VoiceOutputTarget[];
+		} catch (e) {
+			throw new Error(`Failed to get voice outputs: ${e}`);
 		}
 	}
 

--- a/ui/src/lib/adapter/types.ts
+++ b/ui/src/lib/adapter/types.ts
@@ -6,6 +6,26 @@
  */
 
 /** Represents a MIDI device (input or output). */
+/** Maximum number of voices the app exposes. Must match MAX_VOICES in
+ *  `src-tauri/src/state.rs`. */
+export const MAX_VOICES = 8;
+
+/** Per-voice output destination. Shape mirrors the Rust `VoiceOutputTarget`
+ *  enum with `#[serde(tag = "kind", rename_all = "snake_case")]` — see
+ *  `src-tauri/src/state.rs` and the `voice_output_target_json_shape_is_tagged`
+ *  test in `src-tauri/src/commands/routing.rs`.
+ *
+ *    - `use_default` — defer to global routing_mode (legacy behavior)
+ *    - `synth`       — internal synth only, skip MIDI
+ *    - `midi_port`   — specific MIDI port only, skip synth
+ *    - `off`         — voice is silent
+ */
+export type VoiceOutputTarget =
+	| { kind: 'use_default' }
+	| { kind: 'synth' }
+	| { kind: 'midi_port'; port: number }
+	| { kind: 'off' };
+
 export interface MidiDevice {
 	index: number;
 	name: string;
@@ -200,6 +220,22 @@ export interface ContrapunkAdapter {
 
 	/** Stop the currently active MIDI routing. */
 	stopRouting(): Promise<void>;
+
+	// -- Per-voice output routing --
+
+	/**
+	 * Set the output destination for a single voice by index (0..7).
+	 * Each voice can go independently to the internal synth, a specific
+	 * external MIDI port, nowhere (off), or fall back to the global
+	 * routing mode (use_default).
+	 */
+	setVoiceOutput(voiceIdx: number, target: VoiceOutputTarget): Promise<void>;
+
+	/**
+	 * Get the current voice-output routing table. Array length = MAX_VOICES
+	 * (8). Each entry is the destination for that voice index.
+	 */
+	getVoiceOutputs(): Promise<VoiceOutputTarget[]>;
 
 	// -- Real-time state --
 

--- a/ui/src/lib/adapter/wasm.ts
+++ b/ui/src/lib/adapter/wasm.ts
@@ -12,8 +12,10 @@ import type {
 	MidiDevice,
 	NoteState,
 	Preset,
-	TransportState
+	TransportState,
+	VoiceOutputTarget
 } from './types';
+import { MAX_VOICES } from './types';
 import { GuitarAudioCapture } from '$lib/audio/guitarCapture';
 import { guitar } from '$lib/stores/guitar.svelte';
 
@@ -443,6 +445,26 @@ export class WasmAdapter implements ContrapunkAdapter {
 		this.activeOutputs = [];
 		this._isRunning = false;
 		this.stopNotePolling();
+	}
+
+	// Per-voice output routing is native-only for now. The browser path
+	// has no backend to route to — tracked in the in-memory table below
+	// so UI reads/writes round-trip consistently until the WASM engine
+	// gains a synth + MIDI dispatcher of its own.
+	private _voiceOutputs: VoiceOutputTarget[] = Array.from(
+		{ length: MAX_VOICES },
+		() => ({ kind: 'use_default' })
+	);
+
+	async setVoiceOutput(voiceIdx: number, target: VoiceOutputTarget): Promise<void> {
+		if (voiceIdx < 0 || voiceIdx >= MAX_VOICES) {
+			throw new Error(`voiceIdx ${voiceIdx} out of range (0..${MAX_VOICES - 1})`);
+		}
+		this._voiceOutputs[voiceIdx] = target;
+	}
+
+	async getVoiceOutputs(): Promise<VoiceOutputTarget[]> {
+		return this._voiceOutputs.slice();
 	}
 
 	async injectNoteOn(note: number, velocity?: number): Promise<number[]> {


### PR DESCRIPTION
Closes #57. Unblocks #36.

## Summary

Adds per-voice output routing so each voice's destination can be configured independently — internal synth, specific MIDI port, off, or defer to the global routing mode.

**Fixes an existing bug along the way:** before this PR, every engine-emitted note fanned out to BOTH the internal synth AND all connected MIDI ports simultaneously. Users running external MIDI heard every note twice (synth + DAW). The new dispatch consults `voice_outputs[i]` per voice and respects mutual exclusion.

## What's added

**Rust (`src-tauri/`)**
- `state.rs`: `VoiceOutputTarget` enum (tagged serde with `kind` discriminator) + `MAX_VOICES = 8` const + `voice_outputs: Arc<Mutex<Vec<VoiceOutputTarget>>>` field on `AppState`
- `commands/routing.rs` (new): `set_voice_output` + `get_voice_outputs` Tauri commands, with unit tests pinning the serde JSON shape so future Rust changes can't silently break the TS adapter
- `commands/engine.rs`: routing table threaded through `start_routing → run_tauri_router → process_midi_message → handle_note_on/off`. Dispatch rewritten: snapshot `voice_outputs` at each note event, then match per-voice on the target to decide synth / midi / both / neither

**TS adapter (`ui/src/lib/adapter/`)**
- `types.ts`: `VoiceOutputTarget` type + `MAX_VOICES` + two new interface methods
- `tauri.ts`: real implementation via `invoke()`
- `wasm.ts` + `plugin.ts`: in-memory stubs that track the user's selection for UI restoration (no backend to route to in those contexts)

## Safety / compatibility

- **Default: all voices → `UseDefault`** — legacy fan-out behavior preserved exactly for existing users
- No UI changes yet; the new commands just exist. `#36` (output configuration UI) will wire them up
- Legacy `RoutingMode::{ChannelBased, PortBased}` logic is preserved unchanged and runs only when a voice is on `UseDefault`

## Test plan

- [ ] `cargo test -p contrapunk-tauri` — 2 new tests pass (`voice_output_target_roundtrips_through_serde`, `voice_output_target_json_shape_is_tagged`)
- [ ] `cargo fmt --check` + `cargo clippy -- -W clippy::all` — clean on the tauri crate
- [ ] `npm run check` in `ui/` — 0 errors
- [ ] Existing user flow regression check: open the app, start routing with external MIDI selected, play notes — should behave exactly as before (synth + MIDI fan-out, because all voices are still `UseDefault`)
- [ ] Manual smoke test of the new commands: `invoke('set_voice_output', { voiceIdx: 0, target: { kind: 'synth' } })` followed by `invoke('get_voice_outputs')` returns the updated table

## Next

- **#36** — UI rework to expose this via per-voice dropdowns, voice-count-driven slot count, defaults (all-synth for first-run, first-MIDI-device for desktop with devices present)