### PR TITLE
feat(ui/outputs): voice-count-driven slots + per-voice synth/off (#36)

### DIFF
--- a/ui/src/lib/adapter/index.ts
+++ b/ui/src/lib/adapter/index.ts
@@ -63,5 +63,7 @@ export type {
 	NoteState,
 	Preset,
 	SynthState,
-	TransportState
+	TransportState,
+	VoiceOutputTarget
 } from './types';
+export { MAX_VOICES } from './types';

--- a/ui/src/lib/components/MidiDevices.svelte
+++ b/ui/src/lib/components/MidiDevices.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { midi } from '$lib/stores/midi.svelte';
+	import { engine } from '$lib/stores/engine.svelte';
 	import PixelSelect from './PixelSelect.svelte';
 	import type { Snippet } from 'svelte';
 
@@ -10,15 +11,25 @@
 	const VIRTUAL_COMPUTER_KEYBOARD = 999_998;
 	const VIRTUAL_GUITAR_AUDIO = 999_997;
 
+	// Sentinel strings used as <select> values for the non-MIDI-device
+	// slot options. MIDI device options use their numeric device index
+	// stringified. We pick values that can never collide with an int.
+	const SYNTH_VALUE = '__synth__';
+	const OFF_VALUE = '__off__';
+
 	// Auto-refresh on mount if device lists are empty (defensive — page init should
 	// already call midi.refresh(), but this ensures devices show even if that failed).
+	// Also hydrate per-voice routing from localStorage + adapter.
 	onMount(() => {
 		if (midi.inputs.length === 0 && midi.outputs.length === 0 && !midi.isLoading) {
 			midi.refresh();
 		}
+		midi.hydrateVoiceOutputs();
 	});
 
-	const MAX_OUTPUT_SLOTS = 8;
+	// Slot count is driven by the configured voice count (1..8) so the
+	// UI only shows slots that actually produce sound.
+	const slotCount = $derived(Math.max(1, Math.min(engine.voiceCount, 8)));
 
 	// Derived: is Computer Keyboard selected as input?
 	let isComputerKeyboard = $derived(midi.selectedInput === VIRTUAL_COMPUTER_KEYBOARD);
@@ -29,9 +40,13 @@
 		{ value: String(VIRTUAL_GUITAR_AUDIO), label: 'Guitar Audio' }
 	]);
 
-	let outputOptions = $derived(
-		midi.outputs.map((d) => ({ value: String(d.index), label: d.name }))
-	);
+	// Per-slot dropdown options: Internal Synth first (sensible default for
+	// no-MIDI users), then each available MIDI device, then Off last.
+	let outputOptions = $derived([
+		{ value: SYNTH_VALUE, label: 'Internal Synth' },
+		...midi.outputs.map((d) => ({ value: String(d.index), label: d.name })),
+		{ value: OFF_VALUE, label: 'Off' }
+	]);
 
 	function handleInputChange(value: string) {
 		if (value === '') {
@@ -47,28 +62,42 @@
 	}
 
 	function handleOutputChange(slotIndex: number, value: string) {
-		const newOutputs = [...midi.selectedOutputs];
-
-		if (value === '') {
-			if (slotIndex < newOutputs.length) {
-				newOutputs.splice(slotIndex, 1);
-			}
-		} else {
-			const idx = parseInt(value, 10);
-			while (newOutputs.length <= slotIndex) {
-				newOutputs.push(-1);
-			}
-			newOutputs[slotIndex] = idx;
+		if (value === SYNTH_VALUE) {
+			// Per-voice synth: skip external MIDI for this voice.
+			// Keep the positional MIDI device list unchanged so other
+			// voices are not disturbed.
+			midi.setVoiceOutput(slotIndex, { kind: 'synth' });
+			return;
 		}
-
+		if (value === OFF_VALUE) {
+			midi.setVoiceOutput(slotIndex, { kind: 'off' });
+			return;
+		}
+		// MIDI device picked. Revert this voice to default routing (so
+		// the engine's PortBased / ChannelBased logic applies), then
+		// slot the device into the positional selectedOutputs list the
+		// same way it worked before voice_outputs existed.
+		midi.setVoiceOutput(slotIndex, { kind: 'use_default' });
+		const deviceIdx = parseInt(value, 10);
+		if (Number.isNaN(deviceIdx)) return;
+		const newOutputs = [...midi.selectedOutputs];
+		while (newOutputs.length <= slotIndex) {
+			newOutputs.push(-1);
+		}
+		newOutputs[slotIndex] = deviceIdx;
 		midi.selectedOutputs = newOutputs.filter((v) => v >= 0);
 	}
 
 	function getSlotValue(slotIndex: number): string {
+		const t = midi.voiceOutputs[slotIndex];
+		if (t?.kind === 'synth') return SYNTH_VALUE;
+		if (t?.kind === 'off') return OFF_VALUE;
+		// UseDefault or MidiPort → reflect the positional MIDI device
+		// selection (preserves the pre-#36 slot-to-port mapping).
 		if (slotIndex < midi.selectedOutputs.length) {
 			return String(midi.selectedOutputs[slotIndex]);
 		}
-		return '';
+		return SYNTH_VALUE;
 	}
 
 	function slotLabel(index: number): string {
@@ -116,7 +145,7 @@
 	<div class="section-header font-ui">OUTPUTS</div>
 
 	<div class="output-slots">
-		{#each Array.from({ length: MAX_OUTPUT_SLOTS }, (_, i) => i) as slotIdx}
+		{#each Array.from({ length: slotCount }, (_, i) => i) as slotIdx}
 			<div class="output-slot">
 				<span class="slot-label font-ui">{slotLabel(slotIdx)}</span>
 				<PixelSelect

--- a/ui/src/lib/stores/midi.svelte.ts
+++ b/ui/src/lib/stores/midi.svelte.ts
@@ -7,13 +7,35 @@
  */
 
 import { adapter } from '$lib/adapter';
-import type { MidiDevice } from '$lib/adapter';
+import type { MidiDevice, VoiceOutputTarget } from '$lib/adapter';
+import { MAX_VOICES } from '$lib/adapter/types';
 
 const MIDI_SETTINGS_KEY = 'contrapunk-midi';
+const VOICE_OUTPUTS_KEY = 'contrapunk-voice-outputs';
 
 interface MidiSettings {
 	inputName: string | null;
 	outputNames: string[];
+}
+
+function loadVoiceOutputs(): VoiceOutputTarget[] | null {
+	try {
+		const raw = localStorage.getItem(VOICE_OUTPUTS_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return null;
+		return parsed.slice(0, MAX_VOICES);
+	} catch {
+		return null;
+	}
+}
+
+function saveVoiceOutputs(targets: VoiceOutputTarget[]) {
+	try {
+		localStorage.setItem(VOICE_OUTPUTS_KEY, JSON.stringify(targets));
+	} catch {
+		// localStorage unavailable
+	}
 }
 
 function loadMidiSettings(): MidiSettings | null {
@@ -44,6 +66,12 @@ class MidiStore {
 	// -- Selection state --
 	selectedInput = $state<number | null>(null);
 	selectedOutputs = $state<number[]>([]);
+
+	// -- Per-voice output routing (issue #36 / backed by #57) --
+	// Length is always MAX_VOICES. UseDefault preserves legacy behavior.
+	voiceOutputs = $state<VoiceOutputTarget[]>(
+		Array.from({ length: MAX_VOICES }, () => ({ kind: 'use_default' as const }))
+	);
 
 	// -- Loading / error state --
 	isLoading = $state(false);
@@ -180,6 +208,53 @@ class MidiStore {
 	setOutputs(indices: number[]) {
 		this.selectedOutputs = indices.filter((idx) => this.outputs.some((d) => d.index === idx));
 		this.persist();
+	}
+
+	/**
+	 * Set the output destination for a single voice.
+	 * Updates the reactive store, pushes to the backend via the adapter,
+	 * and persists to localStorage so the selection survives reloads.
+	 */
+	async setVoiceOutput(voiceIdx: number, target: VoiceOutputTarget) {
+		if (voiceIdx < 0 || voiceIdx >= MAX_VOICES) return;
+		const next = this.voiceOutputs.slice();
+		next[voiceIdx] = target;
+		this.voiceOutputs = next;
+		saveVoiceOutputs(next);
+		try {
+			await adapter.setVoiceOutput(voiceIdx, target);
+		} catch (e) {
+			this.error = `Failed to set voice output: ${e}`;
+		}
+	}
+
+	/**
+	 * Hydrate voiceOutputs from localStorage and push to the backend.
+	 * Falls back to the backend's current state if no saved selection
+	 * exists (first run, fresh install). Call once at app init.
+	 */
+	async hydrateVoiceOutputs() {
+		const saved = loadVoiceOutputs();
+		if (saved && saved.length > 0) {
+			const padded: VoiceOutputTarget[] = Array.from({ length: MAX_VOICES }, (_, i) =>
+				saved[i] ?? { kind: 'use_default' }
+			);
+			this.voiceOutputs = padded;
+			try {
+				await Promise.all(padded.map((t, i) => adapter.setVoiceOutput(i, t)));
+			} catch {
+				// Non-fatal — UI still reflects user's prior choice
+			}
+			return;
+		}
+		try {
+			const current = await adapter.getVoiceOutputs();
+			if (Array.isArray(current) && current.length === MAX_VOICES) {
+				this.voiceOutputs = current;
+			}
+		} catch {
+			// Adapter may be stubbed (browser / plugin host)
+		}
 	}
 
 	/**


### PR DESCRIPTION
Closes #36. Builds on #57 (per-voice routing infra).

## Summary

- Output slot count now binds to `engine.voiceCount` — 4 voices shows 4 slots, not 8
- Each slot dropdown: **Internal Synth** / every connected MIDI device / **Off**
- Picking Internal Synth → `voice_outputs[i] = Synth` (skip MIDI for this voice)
- Picking Off → `voice_outputs[i] = Off` (voice is silent)
- Picking a MIDI device → reverts to `UseDefault` + keeps the existing positional `selectedOutputs` model (no regression for current users)
- Per-voice routing persists across reloads (`localStorage` key `contrapunk-voice-outputs`) and hydrates on mount

## What's in / out

**In (matches #36 acceptance):**
- [x] Output-slot count binds to voice count, updates live
- [x] Each slot has independent dropdown: external MIDI device(s), internal synth, off
- [x] Internal synth option works on desktop (wired via `set_voice_output` Tauri command from #57)
- [x] Settings persist across reloads
- [x] Reducing voice count hides slots without losing config; increasing restores

**Out (follow-up):**
- Explicit `MidiPort` per-voice override ("voice 0 → device 7 specifically", independent of the positional `selectedOutputs` map). The Rust + adapter support it; UI deferred to avoid conflating "add device to pool" with "pick device for voice" in this cycle.
- Allowing **all-synth routing** (all voices → Internal Synth with no external MIDI device selected) — requires relaxing the "at least one output port required" check in `start_routing`
- VU / activity indicators per slot
- Auto-defaults (first-run browser all-synth; desktop with MIDI → first device). Lands cleanly once #55 ships browser audio.

## Test plan

- [ ] Start app, set voice count = 2 → see exactly 2 slots
- [ ] Set voice count = 4 → see exactly 4; prior selections for voices 0-1 preserved
- [ ] Pick Internal Synth for voice 1 → sound of voice 1 plays through the internal synth, external MIDI devices don't receive voice 1
- [ ] Pick Off for voice 2 → voice 2 is silent everywhere
- [ ] Pick a MIDI device for voice 0 → behaves as before (legacy routing)
- [ ] Reload page → voice output selections preserved exactly
- [ ] Switch to a different voice count and back → per-voice selections stable
- [ ] `prefers-reduced-motion`, ui-scale, font-scale still work

svelte-check: 0 errors, 23 pre-existing warnings unchanged. 3 files changed, +126 / -20.