### PR TITLE
feat(ui): view mode switcher (config + URL + 4 modes) (#44)

### DIFF
--- a/ui/src/lib/components/StatusBar.svelte
+++ b/ui/src/lib/components/StatusBar.svelte
@@ -2,7 +2,20 @@
 	import { engine } from '$lib/stores/engine.svelte';
 	import { midi } from '$lib/stores/midi.svelte';
 	import { ui } from '$lib/stores/ui.svelte';
+	import { VIEW_MODES, type ViewMode } from '$lib/stores/ui.svelte';
 	import TransportBar from './TransportBar.svelte';
+	import PixelSelect from './PixelSelect.svelte';
+
+	const VIEW_MODE_LABELS: Record<ViewMode, string> = {
+		full: 'Full',
+		performance: 'Performance',
+		fretboard: 'Fretboard',
+		piano: 'Piano'
+	};
+	const viewModeOptions = VIEW_MODES.map((m) => ({
+		value: m,
+		label: VIEW_MODE_LABELS[m]
+	}));
 
 	/**
 	 * Toggle MIDI routing on/off.
@@ -72,6 +85,17 @@
 
 	<!-- Spacer -->
 	<div class="spacer"></div>
+
+	<!-- View mode switcher (issue #44) -->
+	<div class="view-mode-picker" title="Switch view mode">
+		<span class="view-mode-label font-ui">View</span>
+		<PixelSelect
+			options={viewModeOptions}
+			value={ui.viewMode}
+			small={true}
+			onchange={(val) => ui.setViewMode(val as ViewMode)}
+		/>
+	</div>
 
 	<!-- Settings -->
 	<button
@@ -168,6 +192,16 @@
 
 	.spacer {
 		flex: 1;
+	}
+
+	.view-mode-picker {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+	.view-mode-label {
+		color: var(--color-text-dim);
+		font-size: var(--font-size-xs);
 	}
 
 	.settings-btn {

--- a/ui/src/lib/stores/ui.svelte.ts
+++ b/ui/src/lib/stores/ui.svelte.ts
@@ -12,11 +12,31 @@ import { platformName } from '$lib/adapter';
 const SCALE_KEY = 'contrapunk-ui-scale';
 const FONT_SCALE_KEY = 'contrapunk-font-scale';
 const NOTE_LABELS_KEY = 'contrapunk-show-note-labels';
+const VIEW_MODE_KEY = 'contrapunk-view-mode';
 
 const MIN_SCALE = 0.75;
 const MAX_SCALE = 2.0;
 const MIN_FONT_SCALE = 0.75;
 const MAX_FONT_SCALE = 1.5;
+
+/** View mode determines which surfaces render — controls how chrome
+ *  the user sees vs. just the playable instruments.
+ *
+ *  - `full` — everything: status bar, tabs, panels, fretboard + piano
+ *  - `performance` — just status bar + history strip + fretboard + piano
+ *    (no setup chrome, ideal for jamming)
+ *  - `fretboard` — only the fretboard (centered, fills viewport)
+ *  - `piano` — only the piano (centered, fills viewport)
+ *
+ *  Pass via `?mode=fretboard` query param, or set live from the
+ *  StatusBar dropdown. URL beats localStorage on first paint.
+ */
+export type ViewMode = 'full' | 'performance' | 'fretboard' | 'piano';
+export const VIEW_MODES: ViewMode[] = ['full', 'performance', 'fretboard', 'piano'];
+
+function isViewMode(s: unknown): s is ViewMode {
+	return typeof s === 'string' && (VIEW_MODES as string[]).includes(s);
+}
 
 // === UI Store (Svelte 5 runes) ===
 
@@ -49,6 +69,10 @@ class UiStore {
 	fontScale = $state(1.0);
 	/** Whether to show "C4", "D#5" etc. labels on active piano keys + fretboard notes. */
 	showNoteLabels = $state(true);
+
+	/** Which surfaces are rendered. Drives the layout in +page.svelte.
+	 *  See ViewMode for semantics. */
+	viewMode = $state<ViewMode>('full');
 
 	/**
 	 * Toggle animations on/off and apply the reduced-motion class
@@ -171,6 +195,58 @@ class UiStore {
 		this.showNoteLabels = on;
 		try {
 			localStorage.setItem(NOTE_LABELS_KEY, on ? 'on' : 'off');
+		} catch {
+			/* localStorage unavailable */
+		}
+	}
+
+	// === View mode ===
+
+	/** Switch view mode. Persists to localStorage and reflects the
+	 *  choice into the URL `?mode=` query param so a copy-pasted
+	 *  link reproduces the current view. */
+	setViewMode(mode: ViewMode) {
+		this.viewMode = mode;
+		try {
+			localStorage.setItem(VIEW_MODE_KEY, mode);
+		} catch {
+			/* localStorage unavailable */
+		}
+		if (typeof window !== 'undefined' && typeof history !== 'undefined') {
+			try {
+				const url = new URL(window.location.href);
+				if (mode === 'full') {
+					url.searchParams.delete('mode');
+				} else {
+					url.searchParams.set('mode', mode);
+				}
+				history.replaceState(null, '', url.toString());
+			} catch {
+				/* URL APIs unavailable (e.g. SSR) */
+			}
+		}
+	}
+
+	/** Resolve the active view mode at app start. Order of precedence:
+	 *  1. `?mode=` URL query param (so embed callers can pin a mode)
+	 *  2. localStorage (so the user's last choice persists)
+	 *  3. Default `full`
+	 *  Call this once early in app init. */
+	restoreViewMode() {
+		if (typeof window === 'undefined') return;
+		try {
+			const params = new URLSearchParams(window.location.search);
+			const fromUrl = params.get('mode');
+			if (isViewMode(fromUrl)) {
+				this.viewMode = fromUrl;
+				return;
+			}
+		} catch {
+			/* URL APIs unavailable */
+		}
+		try {
+			const saved = localStorage.getItem(VIEW_MODE_KEY);
+			if (isViewMode(saved)) this.viewMode = saved;
 		} catch {
 			/* localStorage unavailable */
 		}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -68,6 +68,7 @@
 		(async () => {
 			try {
 				ui.restoreAppearance();
+				ui.restoreViewMode();
 				await adapter.init();
 				await engine.syncFromBackend();
 				await engine.restoreSettings();
@@ -180,58 +181,77 @@
 	<SettingsModal />
 
 	{#if initDone}
-		<!-- Tab switcher -->
-		<div class="tab-strip">
-			<button
-				class="tab-btn font-ui"
-				class:active={ui.activeTab === 'play'}
-				onclick={() => (ui.activeTab = 'play')}
-			>
-				Play
-			</button>
-			<button
-				class="tab-btn font-ui"
-				class:active={ui.activeTab === 'chain'}
-				onclick={() => (ui.activeTab = 'chain')}
-			>
-				Chain
-			</button>
-		</div>
-
-		{#if ui.activeTab === 'play'}
-			<!-- Middle: 3-column content area -->
-			<div class="content-area">
-				<!-- Left column: MIDI devices + Guitar Input + Presets -->
-				<div class="column column-left">
-					<MidiDevices>
-						{#if isGuitarAudioSelected}
-							<GuitarInputPanel />
-						{/if}
-					</MidiDevices>
-					<PresetManager />
-				</div>
-
-				<!-- Center column: Harmony controls -->
-				<div class="column column-center">
-					<ControlPanel />
-				</div>
-
-				<!-- Right column: Active Notes -->
-				<div class="column column-right">
-					<ActiveNotes />
-				</div>
+		{#if ui.viewMode === 'full'}
+			<!-- Tab switcher -->
+			<div class="tab-strip">
+				<button
+					class="tab-btn font-ui"
+					class:active={ui.activeTab === 'play'}
+					onclick={() => (ui.activeTab = 'play')}
+				>
+					Play
+				</button>
+				<button
+					class="tab-btn font-ui"
+					class:active={ui.activeTab === 'chain'}
+					onclick={() => (ui.activeTab = 'chain')}
+				>
+					Chain
+				</button>
 			</div>
 
-			<!-- Bottom: History strip + Fretboard + Sacred piano keyboard -->
-			<div class="piano-area">
+			{#if ui.activeTab === 'play'}
+				<!-- Middle: 3-column content area -->
+				<div class="content-area">
+					<!-- Left column: MIDI devices + Guitar Input + Presets -->
+					<div class="column column-left">
+						<MidiDevices>
+							{#if isGuitarAudioSelected}
+								<GuitarInputPanel />
+							{/if}
+						</MidiDevices>
+						<PresetManager />
+					</div>
+
+					<!-- Center column: Harmony controls -->
+					<div class="column column-center">
+						<ControlPanel />
+					</div>
+
+					<!-- Right column: Active Notes -->
+					<div class="column column-right">
+						<ActiveNotes />
+					</div>
+				</div>
+
+				<!-- Bottom: History strip + Fretboard + Sacred piano keyboard -->
+				<div class="piano-area">
+					<HistoryStrip />
+					<Fretboard />
+					<Piano />
+				</div>
+			{:else}
+				<!-- Chain tab: audio signal flow + synth params -->
+				<div class="chain-area">
+					<ChainPanel />
+				</div>
+			{/if}
+		{:else if ui.viewMode === 'performance'}
+			<!-- Performance: history + both instruments, no setup chrome -->
+			<div class="solo-area piano-area">
 				<HistoryStrip />
 				<Fretboard />
 				<Piano />
 			</div>
-		{:else}
-			<!-- Chain tab: audio signal flow + synth params -->
-			<div class="chain-area">
-				<ChainPanel />
+		{:else if ui.viewMode === 'fretboard'}
+			<!-- Fretboard-only: centered, fills available space -->
+			<div class="solo-area solo-fretboard">
+				<Fretboard />
+			</div>
+		{:else if ui.viewMode === 'piano'}
+			<!-- Piano-only: centered, fills available space -->
+			<div class="solo-area solo-piano">
+				<Piano />
 			</div>
 		{/if}
 	{:else if !initError}
@@ -315,6 +335,29 @@
 	.piano-area {
 		border-top: 1px solid var(--color-border);
 		background: rgba(10, 10, 26, 0.88);
+	}
+
+	/* === Solo view modes (issue #44) ===
+	   Each fills the remaining vertical space below the StatusBar so
+	   single-instrument layouts feel deliberate, not cramped. */
+	.solo-area {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: stretch;
+		padding: 24px clamp(16px, 4vw, 64px);
+		background: rgba(10, 10, 26, 0.88);
+		border-top: 1px solid var(--color-border);
+		overflow: hidden;
+	}
+	.solo-fretboard,
+	.solo-piano {
+		gap: 16px;
+	}
+	/* Performance mode keeps the same look as the bottom strip in full
+	   mode but takes the whole content area. */
+	.solo-area.piano-area {
+		padding: 0;
 	}
 
 	/* === Music-reactive vignette === */


### PR DESCRIPTION
Closes #44.

## Summary

Adds a configurable view mode that picks which surfaces render. Four modes:

| Mode | Shows |
|---|---|
| **full** (default) | everything — tab strip, panels, history, fretboard, piano |
| **performance** | history strip + fretboard + piano (no setup chrome) |
| **fretboard** | fretboard only, fills viewport |
| **piano** | piano only, fills viewport |

## Configuration mechanism

Precedence (top wins):
1. `?mode=` URL query param — `/app?mode=fretboard` pins the mode for embeds + deep links
2. `localStorage` (`contrapunk-view-mode`) — last in-app choice persists across reloads
3. Default `full`

Switching live in the StatusBar dropdown updates the store, persists, AND reflects into the URL via `history.replaceState`, so a copy-pasted address bar reproduces the exact current view. Selecting `full` strips the `?mode=` param.

The StatusBar stays visible in all modes so users can always switch back, see the chord readout, and control the transport.

## Files

- `ui/src/lib/stores/ui.svelte.ts` — `ViewMode` type, `viewMode` reactive state, `setViewMode` + `restoreViewMode`
- `ui/src/routes/+page.svelte` — top-level branch on `ui.viewMode`, new `.solo-area` CSS for centered single-instrument layouts
- `ui/src/lib/components/StatusBar.svelte` — `PixelSelect` dropdown wired to the store

## Test plan

- [ ] Default load → full layout (current behavior unchanged)
- [ ] Pick "Fretboard" from the View dropdown → only fretboard shows; URL gains `?mode=fretboard`
- [ ] Refresh page → fretboard mode persists
- [ ] Manually edit URL to `?mode=piano` → piano-only loads
- [ ] Pick "Full" → URL strips `?mode=`, full layout returns
- [ ] All 4 modes render without crash; StatusBar visible + functional in each
- [ ] Browser back/forward navigation doesn't break the mode (replaceState, not push)
- [ ] Engine state (held notes, chord, BPM) preserved across mode switches