### PR TITLE
feat(midi): "Enable MIDI" permission button on /app (closes website#1)

### DIFF
--- a/ui/src/lib/adapter/index.ts
+++ b/ui/src/lib/adapter/index.ts
@@ -60,6 +60,7 @@ export type {
 	EngineState,
 	GuitarConfig,
 	MidiDevice,
+	MidiPermissionState,
 	NoteState,
 	Preset,
 	SynthState,

--- a/ui/src/lib/adapter/plugin.ts
+++ b/ui/src/lib/adapter/plugin.ts
@@ -12,6 +12,7 @@ import type {
 	EngineState,
 	GuitarConfig,
 	MidiDevice,
+	MidiPermissionState,
 	NoteState,
 	Preset,
 	TransportState,
@@ -139,6 +140,14 @@ export class PluginAdapter implements ContrapunkAdapter {
 	}
 
 	// -- MIDI devices (DAW handles routing in plugin mode) --
+
+	/** DAW manages MIDI for the plugin; no browser permission needed. */
+	readonly midiPermissionState: MidiPermissionState = 'granted';
+
+	/** No-op in plugin mode — host owns MIDI routing. */
+	async requestMidiPermission(): Promise<MidiPermissionState> {
+		return 'granted';
+	}
 
 	async listMidiInputs(): Promise<MidiDevice[]> {
 		return [];

--- a/ui/src/lib/adapter/tauri.ts
+++ b/ui/src/lib/adapter/tauri.ts
@@ -18,6 +18,7 @@ import type {
 	EngineState,
 	GuitarConfig,
 	MidiDevice,
+	MidiPermissionState,
 	NoteState,
 	Preset,
 	ReverbState,
@@ -189,6 +190,14 @@ export class TauriAdapter implements ContrapunkAdapter {
 		} catch (e) {
 			throw new Error(`Failed to set counterpoint strictness: ${e}`);
 		}
+	}
+
+	/** Tauri uses native OS MIDI APIs; no browser-style permission gate. */
+	readonly midiPermissionState: MidiPermissionState = 'granted';
+
+	/** No-op on Tauri — native MIDI is always available. */
+	async requestMidiPermission(): Promise<MidiPermissionState> {
+		return 'granted';
 	}
 
 	async listMidiInputs(): Promise<MidiDevice[]> {

--- a/ui/src/lib/adapter/types.ts
+++ b/ui/src/lib/adapter/types.ts
@@ -29,6 +29,18 @@ export interface MidiDevice {
 	name: string;
 }
 
+/**
+ * Browser MIDI permission state.
+ *
+ * `idle`        — never requested. Triggering a request requires a user gesture.
+ * `granted`     — user accepted; device enumeration works.
+ * `denied`      — user rejected. Recoverable only via browser settings; UI
+ *                 should offer a "Try again" affordance.
+ * `unsupported` — browser does not implement Web MIDI (Firefox historically).
+ *                 Suggest the desktop app.
+ */
+export type MidiPermissionState = 'idle' | 'granted' | 'denied' | 'unsupported';
+
 /** Snapshot of the harmony engine configuration. */
 export interface EngineState {
 	key: string;
@@ -201,6 +213,20 @@ export interface ContrapunkAdapter {
 	setCounterpointStrictness(strictness: string): Promise<void>;
 
 	// -- MIDI devices --
+
+	/**
+	 * Browser-only: request Web MIDI permission via a user gesture.
+	 *
+	 * Adapters that don't gate MIDI behind a gesture (Tauri, Plugin) return
+	 * `'granted'` immediately. The browser adapter calls
+	 * `navigator.requestMIDIAccess()` and resolves with the resulting state.
+	 *
+	 * Callers should gate device enumeration on this returning `'granted'`.
+	 */
+	requestMidiPermission(): Promise<MidiPermissionState>;
+
+	/** Current MIDI permission state. `'granted'` for native paths. */
+	readonly midiPermissionState: MidiPermissionState;
 
 	/** List available MIDI input devices. */
 	listMidiInputs(): Promise<MidiDevice[]>;

--- a/ui/src/lib/adapter/wasm.ts
+++ b/ui/src/lib/adapter/wasm.ts
@@ -10,6 +10,7 @@ import type {
 	EngineState,
 	GuitarConfig,
 	MidiDevice,
+	MidiPermissionState,
 	NoteState,
 	Preset,
 	TransportState,
@@ -43,6 +44,7 @@ export class WasmAdapter implements ContrapunkAdapter {
 	private noteUpdateCallback: ((state: NoteState) => void) | null = null;
 	private pollingHandle: number | null = null;
 	private midiAccess: MIDIAccess | null = null;
+	private _midiPermissionState: MidiPermissionState = 'idle';
 	private activeInput: MIDIInput | null = null;
 	private activeOutputs: MIDIOutput[] = [];
 	private _detuneCents = 0;
@@ -219,24 +221,48 @@ export class WasmAdapter implements ContrapunkAdapter {
 		}
 	}
 
+	/** Current MIDI permission state. */
+	get midiPermissionState(): MidiPermissionState {
+		return this._midiPermissionState;
+	}
+
 	/**
-	 * Ensure Web MIDI Access is available. Caches the MIDIAccess instance.
+	 * Return cached `MIDIAccess` without prompting the user.
+	 *
+	 * `navigator.requestMIDIAccess()` is gated behind a user gesture in
+	 * Chromium-based browsers — calling it at page load fails silently and
+	 * leaves the device list empty. The actual prompt lives in
+	 * `requestMidiPermission()`, invoked from a click handler.
 	 */
-	private async ensureMidiAccess(): Promise<MIDIAccess | null> {
-		if (this.midiAccess) return this.midiAccess;
+	private ensureMidiAccess(): MIDIAccess | null {
+		return this.midiAccess;
+	}
+
+	/**
+	 * Trigger the Web MIDI permission prompt. Must be called from inside a
+	 * user-gesture handler (click, keydown). Idempotent — safe to call after
+	 * grant or denial; reports the resulting state via the return value.
+	 */
+	async requestMidiPermission(): Promise<MidiPermissionState> {
 		if (typeof navigator === 'undefined' || !('requestMIDIAccess' in navigator)) {
-			return null;
+			this._midiPermissionState = 'unsupported';
+			return this._midiPermissionState;
+		}
+		if (this.midiAccess) {
+			this._midiPermissionState = 'granted';
+			return this._midiPermissionState;
 		}
 		try {
 			this.midiAccess = await navigator.requestMIDIAccess();
-			return this.midiAccess;
+			this._midiPermissionState = 'granted';
 		} catch {
-			return null;
+			this._midiPermissionState = 'denied';
 		}
+		return this._midiPermissionState;
 	}
 
 	async listMidiInputs(): Promise<MidiDevice[]> {
-		const access = await this.ensureMidiAccess();
+		const access = this.ensureMidiAccess();
 		if (!access) return [];
 		const devices: MidiDevice[] = [];
 		let index = 0;
@@ -247,7 +273,7 @@ export class WasmAdapter implements ContrapunkAdapter {
 	}
 
 	async listMidiOutputs(): Promise<MidiDevice[]> {
-		const access = await this.ensureMidiAccess();
+		const access = this.ensureMidiAccess();
 		if (!access) return [];
 		const devices: MidiDevice[] = [];
 		let index = 0;
@@ -258,8 +284,16 @@ export class WasmAdapter implements ContrapunkAdapter {
 	}
 
 	async refreshMidiDevices(): Promise<void> {
-		// Clear cached access so next list call re-enumerates
-		this.midiAccess = null;
+		if (this._midiPermissionState !== 'granted') return;
+		// Permission was already granted, so the browser will not re-prompt.
+		// Re-acquire so newly connected devices show up; if the user revoked
+		// permission via browser settings since the last grant, fall back.
+		try {
+			this.midiAccess = await navigator.requestMIDIAccess();
+		} catch {
+			this.midiAccess = null;
+			this._midiPermissionState = 'denied';
+		}
 	}
 
 	async startRouting(inputIdx: number, outputIndices: number[]): Promise<void> {
@@ -271,9 +305,10 @@ export class WasmAdapter implements ContrapunkAdapter {
 			return;
 		}
 
-		const access = await this.ensureMidiAccess();
+		const access = this.ensureMidiAccess();
 		if (!access) {
-			// No Web MIDI: still allow "running" for virtual/keyboard input
+			// No Web MIDI (permission not granted, or unsupported browser):
+			// still allow "running" for virtual/keyboard input.
 			this._isRunning = true;
 			return;
 		}
@@ -348,7 +383,7 @@ export class WasmAdapter implements ContrapunkAdapter {
 	 */
 	private async startGuitarCapture(outputIndices: number[]): Promise<void> {
 		// Resolve MIDI outputs for sending harmony notes
-		const access = await this.ensureMidiAccess();
+		const access = this.ensureMidiAccess();
 		if (access) {
 			const outputs = Array.from(access.outputs.values());
 			this.activeOutputs = outputIndices

--- a/ui/src/lib/components/MidiDevices.svelte
+++ b/ui/src/lib/components/MidiDevices.svelte
@@ -2,10 +2,28 @@
 	import { onMount } from 'svelte';
 	import { midi } from '$lib/stores/midi.svelte';
 	import { engine } from '$lib/stores/engine.svelte';
+	import { platformName } from '$lib/adapter';
 	import PixelSelect from './PixelSelect.svelte';
 	import type { Snippet } from 'svelte';
 
 	let { children }: { children?: Snippet } = $props();
+
+	// Browser-only permission state. Tauri / Plugin paths report `'granted'`
+	// from the adapter so this whole block disappears in those builds.
+	let enabling = $state(false);
+	const showPermissionCard = $derived(
+		platformName === 'browser' && midi.permissionState !== 'granted'
+	);
+
+	async function onEnableMidi() {
+		if (enabling) return;
+		enabling = true;
+		try {
+			await midi.requestPermission();
+		} finally {
+			enabling = false;
+		}
+	}
 
 	// Virtual input sentinel values — must match src-tauri/src/commands/engine.rs
 	const VIRTUAL_COMPUTER_KEYBOARD = 999_998;
@@ -139,6 +157,54 @@
 		return `Voice ${index + 1}`;
 	}
 </script>
+
+{#if showPermissionCard}
+	<!-- Web MIDI permission card. Browsers gate
+	     `navigator.requestMIDIAccess()` behind a user gesture, so on first
+	     visit (and any time permission is denied or unsupported) the user
+	     needs an explicit affordance to trigger the prompt. -->
+	<div class="midi-section pixel-card midi-permission-card">
+		<div class="section-header font-ui">MIDI</div>
+
+		{#if midi.permissionState === 'idle'}
+			<p class="permission-text font-ui">
+				Connect external MIDI keyboards, controllers, and synths.
+			</p>
+			<button
+				class="permission-btn pixel-btn font-ui"
+				onclick={onEnableMidi}
+				disabled={enabling}
+			>
+				{enabling ? 'REQUESTING…' : 'ENABLE MIDI'}
+			</button>
+		{:else if midi.permissionState === 'denied'}
+			<p class="permission-text error font-ui">
+				MIDI permission denied. Open your browser's site settings to allow it,
+				then try again.
+			</p>
+			<button
+				class="permission-btn pixel-btn font-ui"
+				onclick={onEnableMidi}
+				disabled={enabling}
+			>
+				{enabling ? 'TRYING…' : 'TRY AGAIN'}
+			</button>
+		{:else if midi.permissionState === 'unsupported'}
+			<p class="permission-text font-ui">
+				Your browser doesn't support Web MIDI. Use Chrome, Edge, or Opera —
+				or run Contrapunk natively on the desktop:
+			</p>
+			<a
+				class="permission-btn pixel-btn font-ui"
+				href="https://contrapunk.com"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				DOWNLOAD DESKTOP APP →
+			</a>
+		{/if}
+	</div>
+{/if}
 
 <!-- Input Device Section -->
 <div class="midi-section pixel-card">
@@ -317,5 +383,39 @@
 		min-width: 56px;
 		-webkit-font-smoothing: none;
 		text-rendering: optimizeSpeed;
+	}
+
+	.midi-permission-card {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.permission-text {
+		color: var(--color-text-secondary);
+		font-size: var(--font-size-xs);
+		line-height: 1.5;
+		margin: 0;
+		-webkit-font-smoothing: none;
+		text-rendering: optimizeSpeed;
+	}
+
+	.permission-text.error {
+		color: #ff4466;
+	}
+
+	.permission-btn {
+		display: inline-block;
+		text-align: center;
+		padding: 6px 10px;
+		font-size: var(--font-size-xs);
+		text-decoration: none;
+		color: var(--color-accent-cyan);
+		cursor: pointer;
+	}
+
+	.permission-btn[disabled] {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 </style>

--- a/ui/src/lib/stores/midi.svelte.ts
+++ b/ui/src/lib/stores/midi.svelte.ts
@@ -6,12 +6,13 @@
  * localStorage so they survive page reloads.
  */
 
-import { adapter } from '$lib/adapter';
-import type { MidiDevice, VoiceOutputTarget } from '$lib/adapter';
+import { adapter, platformName } from '$lib/adapter';
+import type { MidiDevice, MidiPermissionState, VoiceOutputTarget } from '$lib/adapter';
 import { MAX_VOICES } from '$lib/adapter/types';
 
 const MIDI_SETTINGS_KEY = 'contrapunk-midi';
 const VOICE_OUTPUTS_KEY = 'contrapunk-voice-outputs';
+const MIDI_PERMISSION_KEY = 'contrapunk-midi-permission';
 
 interface MidiSettings {
 	inputName: string | null;
@@ -72,7 +73,36 @@ function saveMidiSettings(settings: MidiSettings) {
 	}
 }
 
+function loadPermissionState(): MidiPermissionState | null {
+	try {
+		const raw = localStorage.getItem(MIDI_PERMISSION_KEY);
+		if (raw === 'granted' || raw === 'denied' || raw === 'idle' || raw === 'unsupported') {
+			return raw;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function savePermissionState(state: MidiPermissionState) {
+	try {
+		localStorage.setItem(MIDI_PERMISSION_KEY, state);
+	} catch {
+		// localStorage unavailable
+	}
+}
+
 // === MIDI Store (Svelte 5 runes) ===
+
+/** Initial permission state for store construction. Native paths
+ *  (Tauri / Plugin) report `'granted'` from the adapter and don't need a
+ *  user gesture; the browser path hydrates from localStorage so a returning
+ *  user with prior consent skips the prompt UI. */
+function initialPermissionState(): MidiPermissionState {
+	if (platformName !== 'browser') return 'granted';
+	return loadPermissionState() ?? 'idle';
+}
 
 class MidiStore {
 	// -- Available devices --
@@ -82,6 +112,10 @@ class MidiStore {
 	// -- Selection state --
 	selectedInput = $state<number | null>(null);
 	selectedOutputs = $state<number[]>([]);
+
+	/** Web MIDI permission state. Native paths report `'granted'`; the
+	 *  browser path drives the "Enable MIDI" UI. */
+	permissionState = $state<MidiPermissionState>(initialPermissionState());
 
 	// -- Per-voice output routing (issue #36 / backed by #57) --
 	// Length is always MAX_VOICES. Default is `synth` — first run plays
@@ -95,10 +129,56 @@ class MidiStore {
 	error = $state<string | null>(null);
 
 	/**
+	 * Trigger the Web MIDI permission prompt. Browser-only; safe to call
+	 * on Tauri / Plugin (resolves immediately to `'granted'`).
+	 *
+	 * Must be invoked from inside a user gesture (click, keydown). On grant,
+	 * automatically populates the device list. Persists the resulting state
+	 * to localStorage so subsequent visits skip the prompt UI.
+	 */
+	async requestPermission(): Promise<MidiPermissionState> {
+		const next = await adapter.requestMidiPermission();
+		this.permissionState = next;
+		if (platformName === 'browser') savePermissionState(next);
+		if (next === 'granted') {
+			await this.refresh();
+		}
+		return next;
+	}
+
+	/**
+	 * Re-acquire MIDI access on app startup if the user previously granted it.
+	 *
+	 * Browser permission persists across reloads, so calling
+	 * `navigator.requestMIDIAccess()` again resolves silently without a
+	 * prompt — but we still need to actually call it so the WasmAdapter
+	 * caches a fresh `MIDIAccess` instance for this page lifetime.
+	 *
+	 * If the user revoked permission via browser settings since the last
+	 * grant, falls back to `'denied'` and the UI re-renders the button.
+	 */
+	async hydratePermission(): Promise<void> {
+		if (this.permissionState !== 'granted') return;
+		const next = await adapter.requestMidiPermission();
+		this.permissionState = next;
+		if (platformName === 'browser') savePermissionState(next);
+		if (next === 'granted') {
+			await this.refresh();
+		}
+	}
+
+	/**
 	 * Refresh the list of available MIDI devices from the backend.
 	 * After refreshing, restores previously selected devices by name.
+	 *
+	 * No-op when permission has not been granted on the browser path —
+	 * `navigator.requestMIDIAccess()` requires a user gesture, so a refresh
+	 * triggered at page load would silently leave the device list empty
+	 * and confuse the user. The "Enable MIDI" button in MidiDevices.svelte
+	 * provides the gesture and calls `requestPermission()` instead.
 	 */
 	async refresh() {
+		if (this.permissionState !== 'granted') return;
 		this.isLoading = true;
 		this.error = null;
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -43,7 +43,11 @@
 				await adapter.init();
 				await engine.syncFromBackend();
 				await engine.restoreSettings();
-				await midi.refresh();
+				// Browser path: only refreshes devices if the user previously
+				// granted Web MIDI access. First-time visitors see the
+				// "Enable MIDI" button in MidiDevices.svelte instead.
+				// Tauri / Plugin: resolves immediately and refreshes.
+				await midi.hydratePermission();
 				await synth.syncFromBackend();
 				initDone = true;
 			} catch (e) {


### PR DESCRIPTION
Closes website#1. The browser path was calling \`navigator.requestMIDIAccess()\` at page load — Chromium gates it behind a user gesture, so the call failed silently and the device dropdown stayed empty. This adds an explicit affordance to trigger the prompt and persists the result so returning users skip the UI.

> ⚠️ **Base:** \`outputs-voice-count-inline\` (= PR #67), not \`main\`. The MIDI work touches files (\`MidiDevices.svelte\`, \`+page.svelte\`, \`wasm.ts\`) whose context comes from the follow-up branch. Once #67 merges, this can be re-targeted to \`main\`.

## Summary

**Adapter layer**
- New \`MidiPermissionState\` type (\`'idle'|'granted'|'denied'|'unsupported'\`)
- \`requestMidiPermission()\` + \`midiPermissionState\` on the \`ContrapunkAdapter\` interface
- WasmAdapter: \`ensureMidiAccess\` is now passive (returns cached); public \`requestMidiPermission()\` does the prompt; \`refreshMidiDevices()\` re-acquires only if previously granted
- TauriAdapter / PluginAdapter: stub returning \`'granted'\` (native paths don't need a browser gesture)

**Store layer (\`midi.svelte.ts\`)**
- \`permissionState\` reactive field, persisted to localStorage
- \`requestPermission()\` invokes the prompt + auto-refreshes device list on grant
- \`hydratePermission()\` re-acquires silently on app startup if previously granted (caches a fresh \`MIDIAccess\` for this page lifetime)
- \`refresh()\` is a no-op until permission is granted

**UI (\`MidiDevices.svelte\`)**
- Permission card renders only on browser path when state ≠ \`'granted'\`
- Idle: "ENABLE MIDI" button → triggers prompt
- Denied: error message + "TRY AGAIN"
- Unsupported (Firefox etc.): download-desktop-app fallback link

Auto-refresh-at-page-init in \`+page.svelte\` replaced by \`midi.hydratePermission()\` (no-op when permission isn't already granted).

## Test plan
- [ ] \`npm run check\` clean
- [ ] First-time browser visit → ENABLE MIDI card visible, dropdown empty
- [ ] Click → permission prompt → grant → device list populates, card disappears
- [ ] Reload after grant → no card, devices still listed
- [ ] Deny → error + TRY AGAIN affordance
- [ ] Firefox / unsupported browser → desktop-app link
- [ ] Tauri build unchanged (stub returns \`'granted'\` immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)