### PR TITLE
ci: add website-compat build check on canonical-file PRs

### DIFF
--- a/.github/workflows/website-compat.yml
+++ b/.github/workflows/website-compat.yml
@@ -1,0 +1,56 @@
+name: Website Compat
+
+# Build the contrapunk-audio/website with this PR's contrapunk code.
+# Catches breakage in the canonical embed surface, keyboard-input, or
+# wasm-pkg before it ships.
+#
+# Only runs when the canonical files change — most contrapunk PRs do
+# not touch the website-shared bits and skip this job entirely.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ui/src/lib/embed/**'
+      - 'ui/src/lib/keyboard-input.ts'
+      - 'ui/src/lib/wasm-pkg/**'
+      - '.github/workflows/website-compat.yml'
+
+jobs:
+  website-build:
+    name: Website builds with this PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout contrapunk PR
+        uses: actions/checkout@v6
+        with:
+          path: contrapunk
+
+      - name: Checkout website main
+        uses: actions/checkout@v6
+        with:
+          repository: contrapunk-audio/website
+          ref: main
+          path: website
+          # Skip submodule init — we override `vendor/contrapunk` with
+          # this PR's contrapunk checkout below.
+          submodules: false
+
+      - name: Inject this PR's contrapunk into the website's submodule path
+        run: |
+          rm -rf website/vendor/contrapunk
+          cp -r contrapunk website/vendor/contrapunk
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install website deps
+        working-directory: website
+        run: npm ci
+
+      - name: Build website
+        working-directory: website
+        run: npm run build


### PR DESCRIPTION
Implements **Option C** from #70. When a PR touches files the website depends on, build the website with this PR's contrapunk code and fail if it breaks.

## How it works

\`\`\`yaml
on:
  pull_request:
    paths:
      - 'ui/src/lib/embed/**'
      - 'ui/src/lib/keyboard-input.ts'
      - 'ui/src/lib/wasm-pkg/**'
\`\`\`

Workflow steps:
1. Checkout contrapunk PR head
2. Checkout \`contrapunk-audio/website@main\` as a sibling, **without** initializing its submodule
3. \`rm -rf website/vendor/contrapunk && cp -r contrapunk website/vendor/contrapunk\` — overrides the website's pinned submodule with this PR's contrapunk
4. \`npm ci && npm run build\` in the website

If the build breaks, the PR fails its required check.

## Dependency

Becomes meaningful after contrapunk-audio/website's submodule PR merges (the website needs \`vendor/contrapunk\` to exist as a path the workflow can override). Until then the job will still run on canonical-file PRs but the website's own vendored copies are still in use, so the build doesn't actually exercise the PR's changes.

## Test plan
- [ ] PR touching \`ui/src/lib/embed/audio.ts\` triggers the job
- [ ] PR not touching shared paths skips it
- [ ] After website submodule PR merges, breaking change to canonical files makes this job red

Refs #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)