### PR TITLE
fix(tauri): share HarmonyEngine across command handlers and router thread

### DIFF
--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -116,23 +116,11 @@ pub fn start_routing(
     // at least one external MIDI port; that constraint is gone now
     // that per-voice routing is the source of truth.
 
-    // Capture engine config for the router thread
-    let engine_config = {
-        let engine = state.engine.lock().map_err(|e| e.to_string())?;
-        (
-            engine.key(),
-            engine.mode(),
-            engine.octave_mode(),
-            engine.voice_leading_enabled(),
-            engine.voice_leading_style(),
-            engine.scale_mode(),
-            engine.interchange_enabled(),
-            engine.borrowing_range(),
-            engine.voice_position(),
-            engine.counterpoint_species(),
-            engine.counterpoint_strictness(),
-        )
-    };
+    // Share the engine across the router thread and command handlers.
+    // Without this clone, the router would run on its own private engine
+    // instance and would never see param changes (set_key, set_auto_key,
+    // ...) made via Tauri commands during a routing session.
+    let engine = Arc::clone(&state.engine);
 
     let routing_mode = { *state.routing_mode.lock().map_err(|e| e.to_string())? };
 
@@ -222,7 +210,7 @@ pub fn start_routing(
         if let Err(e) = run_tauri_router(
             input_idx,
             &output_indices_clone,
-            engine_config,
+            engine,
             routing_mode,
             is_guitar,
             guitar_device,
@@ -290,25 +278,11 @@ pub fn stop_routing(state: State<AppState>) -> Result<(), String> {
 // Router thread implementation
 // ============================================================================
 
-type EngineConfig = (
-    contrapunk::harmony::Key,
-    contrapunk::harmony::HarmonyMode,
-    contrapunk::harmony::OctaveMode,
-    bool, // voice_leading_enabled
-    contrapunk::harmony::VoiceLeadingStyle,
-    contrapunk::harmony::ScaleMode,
-    bool,  // interchange_enabled
-    u8,    // borrowing_range
-    usize, // voice_position
-    contrapunk::harmony::CounterpointSpecies,
-    contrapunk::harmony::CounterpointStrictness,
-);
-
 #[allow(clippy::too_many_arguments)]
 fn run_tauri_router(
     input_port: usize,
     output_ports: &[usize],
-    config: EngineConfig,
+    engine: Arc<Mutex<HarmonyEngine>>,
     routing_mode: contrapunk::harmony::RoutingMode,
     is_guitar: bool,
     guitar_device: String,
@@ -327,20 +301,6 @@ fn run_tauri_router(
     synth_tx: mpsc::Sender<SynthEvent>,
     voice_outputs: Arc<Mutex<Vec<VoiceOutputTarget>>>,
 ) -> anyhow::Result<()> {
-    let (
-        key,
-        mode,
-        octave_mode,
-        vl_enabled,
-        vl_style,
-        scale_mode,
-        ic_enabled,
-        br_range,
-        vp,
-        cp_species,
-        cp_strictness,
-    ) = config;
-
     // Connect to either Guitar Audio bridge, physical MIDI input, or
     // nothing at all (Computer Keyboard virtual input — notes are pushed
     // by inject_note_on/off commands via the shared router_tx).
@@ -383,18 +343,15 @@ fn run_tauri_router(
     let mut output_router = OutputRouter::new(output_ports)?;
     let num_outputs = output_router.connection_count();
 
-    // Create harmony engine
-    let mut engine = HarmonyEngine::new(key, mode);
-    engine.set_voice_count(num_outputs);
-    engine.set_octave_mode(octave_mode);
-    engine.set_voice_leading_enabled(vl_enabled);
-    engine.set_voice_leading_style(vl_style);
-    engine.set_scale_mode(scale_mode);
-    engine.set_interchange_enabled(ic_enabled);
-    engine.set_borrowing_range(br_range);
-    engine.set_voice_position(vp);
-    engine.set_counterpoint_species(cp_species);
-    engine.set_counterpoint_strictness(cp_strictness);
+    // Sync voice_count to the number of routable outputs at the start of
+    // the session. All other engine parameters (key, mode, scale, voice
+    // leading, etc.) are user-driven and already live on `engine`; we
+    // share that instance with the Tauri command handlers so changes
+    // made during the session take effect on this routing pass.
+    {
+        let mut eng = engine.lock().unwrap_or_else(|e| e.into_inner());
+        eng.set_voice_count(num_outputs);
+    }
 
     // Event emission timer (~30fps)
     let mut last_emit = Instant::now();
@@ -453,7 +410,7 @@ fn run_tauri_router(
             Ok(message) => {
                 process_midi_message(
                     &message,
-                    &mut engine,
+                    &engine,
                     &mut output_router,
                     &input_notes,
                     &harmony_notes,
@@ -478,6 +435,15 @@ fn run_tauri_router(
             // thread. A poisoned lock means a thread panicked while holding
             // it — the data is likely still usable, and silently crashing
             // the emit loop leaves the UI stuck with no user-visible error.
+            let (last_borrowed_from, current_key) = {
+                let eng = engine.lock().unwrap_or_else(|e| e.into_inner());
+                (
+                    eng.last_borrowed_from()
+                        .map(|m| format!("{}", m))
+                        .unwrap_or_default(),
+                    format!("{}", eng.key()),
+                )
+            };
             let payload = {
                 let in_notes = input_notes.lock().unwrap_or_else(|e| e.into_inner());
                 let harm_notes = harmony_notes.lock().unwrap_or_else(|e| e.into_inner());
@@ -494,11 +460,8 @@ fn run_tauri_router(
                     harmony_notes: harm_vec,
                     borrowed_notes: borr_vec,
                     chord_name: ch_name.clone(),
-                    last_borrowed_from: engine
-                        .last_borrowed_from()
-                        .map(|m| format!("{}", m))
-                        .unwrap_or_default(),
-                    current_key: format!("{}", engine.key()),
+                    last_borrowed_from,
+                    current_key,
                 }
             };
             let _ = app_handle.emit("note-update", payload);
@@ -559,7 +522,7 @@ fn run_tauri_router(
 #[allow(clippy::too_many_arguments)]
 fn process_midi_message(
     bytes: &[u8],
-    engine: &mut HarmonyEngine,
+    engine: &Arc<Mutex<HarmonyEngine>>,
     output: &mut OutputRouter,
     input_notes: &Arc<Mutex<HashSet<u8>>>,
     harmony_notes: &Arc<Mutex<HashSet<u8>>>,
@@ -577,6 +540,12 @@ fn process_midi_message(
         }
     };
 
+    // Lock the shared engine for the duration of one MIDI message. Held
+    // briefly enough that Tauri command handlers (set_key etc.) waiting
+    // on the same Mutex pick it up between messages.
+    let mut eng = engine.lock().unwrap_or_else(|e| e.into_inner());
+    let eng: &mut HarmonyEngine = &mut eng;
+
     match msg {
         MidiMessage::NoteOn(channel, note, velocity) => {
             if velocity == Velocity::MIN {
@@ -584,7 +553,7 @@ fn process_midi_message(
                     channel,
                     note,
                     velocity,
-                    engine,
+                    eng,
                     output,
                     input_notes,
                     harmony_notes,
@@ -599,7 +568,7 @@ fn process_midi_message(
                     channel,
                     note,
                     velocity,
-                    engine,
+                    eng,
                     output,
                     input_notes,
                     harmony_notes,
@@ -616,7 +585,7 @@ fn process_midi_message(
                 channel,
                 note,
                 velocity,
-                engine,
+                eng,
                 output,
                 input_notes,
                 harmony_notes,
@@ -649,7 +618,34 @@ fn handle_note_on(
     voice_outputs: &Arc<Mutex<Vec<VoiceOutputTarget>>>,
 ) {
     let notes = engine.harmonize_note_on(note);
+    // Drain any harmonies the engine flagged for explicit release —
+    // populated when an auto-key change wiped `active_notes` mid-flight.
+    // These would otherwise stay sounding under the old key.
+    let stale_releases = engine.take_pending_releases();
     let num_outputs = output.connection_count();
+
+    // Send Note-Offs for stale harmonies before emitting the new ones.
+    // Sending to every external port is over-broad (each note went out
+    // on a single port), but extra Note-Offs to ports that didn't see
+    // the matching Note-On are harmless and we don't track per-note
+    // routing on the router side.
+    if !stale_releases.is_empty() {
+        for &n in &stale_releases {
+            let _ = synth_tx.send(SynthEvent::NoteOff { note: u8::from(n) });
+            let msg = MidiMessage::NoteOff(channel, n, velocity);
+            let mut buf = vec![0u8; msg.bytes_size()];
+            let _ = msg.copy_to_slice(&mut buf);
+            for port in 0..num_outputs {
+                let _ = output.send_to_port(port, &buf);
+            }
+        }
+        let mut harm = harmony_notes.lock().unwrap_or_else(|e| e.into_inner());
+        let mut borr = borrowed_notes.lock().unwrap_or_else(|e| e.into_inner());
+        for &n in &stale_releases {
+            harm.remove(&u8::from(n));
+            borr.remove(&u8::from(n));
+        }
+    }
 
     // Snapshot voice routing once per note event — clone is cheap
     // (8-element Vec of Copy enums) and avoids lock contention during

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -47,8 +47,14 @@ pub enum VoiceOutputTarget {
 /// and real-time note state in thread-safe containers for access from
 /// both the main thread (command handlers) and the router thread.
 pub struct AppState {
-    /// Core harmony engine (key, mode, scale, voice leading, etc.)
-    pub engine: Mutex<HarmonyEngine>,
+    /// Core harmony engine (key, mode, scale, voice leading, etc.).
+    ///
+    /// Wrapped in `Arc<Mutex<...>>` so the router thread (spawned by
+    /// `start_routing`) and the Tauri command handlers operate on the
+    /// same instance — without this sharing, mid-session parameter
+    /// changes (set_key, set_auto_key, etc.) would not reach the live
+    /// MIDI processing path.
+    pub engine: Arc<Mutex<HarmonyEngine>>,
 
     /// Preset manager for built-in and custom presets
     pub preset_manager: Mutex<PresetManager>,
@@ -148,7 +154,7 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            engine: Mutex::new(HarmonyEngine::new(Key::C, HarmonyMode::PassThrough)),
+            engine: Arc::new(Mutex::new(HarmonyEngine::new(Key::C, HarmonyMode::PassThrough))),
             preset_manager: Mutex::new(PresetManager::new()),
             is_running: AtomicBool::new(false),
             input_notes: Mutex::new(HashSet::new()),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -154,7 +154,10 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            engine: Arc::new(Mutex::new(HarmonyEngine::new(Key::C, HarmonyMode::PassThrough))),
+            engine: Arc::new(Mutex::new(HarmonyEngine::new(
+                Key::C,
+                HarmonyMode::PassThrough,
+            ))),
             preset_manager: Mutex::new(PresetManager::new()),
             is_running: AtomicBool::new(false),
             input_notes: Mutex::new(HashSet::new()),

--- a/src/harmony/engine.rs
+++ b/src/harmony/engine.rs
@@ -271,6 +271,13 @@ pub struct HarmonyEngine {
     counterpoint_strictness: CounterpointStrictness,
     saved_scale_mode: Option<ScaleMode>,
     harmonic_context: Option<HarmonicContext>,
+    /// Harmony notes that need an explicit Note-Off after an auto-key
+    /// triggered `set_key`. The key change wipes `active_notes`, which
+    /// means the normal Note-Off path (`harmonize_note_off`) won't know
+    /// about the harmonies that were sounding under the previous key —
+    /// they would otherwise stay stuck. Drained by the router each
+    /// `harmonize_note_on` cycle via `take_pending_releases`.
+    pending_releases: Vec<Note>,
 }
 
 impl HarmonyEngine {
@@ -315,6 +322,7 @@ impl HarmonyEngine {
             counterpoint_species: CounterpointSpecies::default(),
             counterpoint_strictness: CounterpointStrictness::default(),
             saved_scale_mode: None,
+            pending_releases: Vec::new(),
             harmonic_context: None,
         }
     }
@@ -462,8 +470,13 @@ impl HarmonyEngine {
         self.auto_key = enabled;
         if enabled {
             self.key_detector.set_scale_mode(self.scale_mode);
+            println!(
+                "[AUTOKEY] enabled (scale_mode={:?}, key={:?})",
+                self.scale_mode, self.key
+            );
         } else {
             self.key_detector.reset();
+            println!("[AUTOKEY] disabled");
         }
     }
 
@@ -1063,6 +1076,21 @@ impl HarmonyEngine {
             let midi = u8::from(note);
             if let Some(detected) = self.key_detector.feed(midi) {
                 if detected != self.key {
+                    // Capture all currently-sounding harmonies for explicit
+                    // release before set_key wipes `active_notes`. Without
+                    // this the old-key harmonies stay stuck — note-off for
+                    // the user's input note only releases harmonies the
+                    // engine is now tracking under the new key.
+                    for harmonies in self.active_notes.values() {
+                        self.pending_releases.extend(harmonies.iter().copied());
+                    }
+                    println!(
+                        "[AUTOKEY] key change: {:?} -> {:?} (note={}, releasing {} stale)",
+                        self.key,
+                        detected,
+                        midi,
+                        self.pending_releases.len()
+                    );
                     self.set_key(detected);
                 }
             }
@@ -1095,6 +1123,16 @@ impl HarmonyEngine {
     ///
     /// Vec of notes to release: original note first, tracked harmony notes after.
     /// If no harmony was tracked, returns just the original note.
+    /// Returns and clears the queue of harmony notes that need an
+    /// explicit Note-Off after an auto-key triggered key change.
+    ///
+    /// The router calls this after each `harmonize_note_on` so the old
+    /// key's stale harmonies get released before the new key's harmonies
+    /// take over. Returns an empty Vec when no key change happened.
+    pub fn take_pending_releases(&mut self) -> Vec<Note> {
+        std::mem::take(&mut self.pending_releases)
+    }
+
     pub fn harmonize_note_off(&mut self, note: Note) -> Vec<Note> {
         let midi = u8::from(note);
         // Restore the port map that was stored during Note-On
@@ -2050,5 +2088,86 @@ mod tests {
             "Species 1 and Species 2 produced identical output across the \
              full melody — species dispatch is not wired end-to-end."
         );
+    }
+
+    // --- Auto-key stuck-note release wiring ---
+
+    #[test]
+    fn auto_key_off_never_populates_pending_releases() {
+        let mut engine = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 2);
+        // auto_key is false by default; play a phrase that would otherwise
+        // shift a key detector strongly.
+        let _ = engine.harmonize_note_on(Note::C4);
+        let _ = engine.harmonize_note_on(Note::E4);
+        let _ = engine.harmonize_note_on(Note::G4);
+        assert!(engine.take_pending_releases().is_empty());
+    }
+
+    #[test]
+    fn auto_key_change_queues_old_harmonies_for_release() {
+        // Stage 1: lock the detector on C major while holding harmony notes
+        // for several inputs. After enabling auto-key those harmonies are
+        // tracked under `active_notes`.
+        let mut engine = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 2);
+        engine.set_auto_key(true);
+        for &n in &[Note::C4, Note::D4, Note::E4, Note::F4, Note::G4] {
+            let _ = engine.harmonize_note_on(n);
+        }
+        assert!(engine.take_pending_releases().is_empty());
+
+        // Stage 2: feed sustained G-major content (full scale, repeated) so
+        // the histogram clearly tilts toward G past the confidence margin.
+        // The old C-major harmonies must be queued for release before
+        // `set_key` wipes `active_notes`.
+        let g_major_scale = [
+            Note::G4,
+            Note::A4,
+            Note::B4,
+            Note::C5,
+            Note::D5,
+            Note::E5,
+            Note::FSharp5,
+        ];
+        for _ in 0..3 {
+            for &n in &g_major_scale {
+                let _ = engine.harmonize_note_on(n);
+            }
+        }
+        let stale = engine.take_pending_releases();
+        assert!(
+            !stale.is_empty(),
+            "auto-key change should queue stale harmonies for release"
+        );
+        assert_eq!(
+            engine.key(),
+            Key::G,
+            "detector should have committed to G after sustained content"
+        );
+    }
+
+    #[test]
+    fn take_pending_releases_drains_the_queue() {
+        let mut engine = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 2);
+        engine.set_auto_key(true);
+        for &n in &[Note::C4, Note::D4, Note::E4, Note::F4, Note::G4] {
+            let _ = engine.harmonize_note_on(n);
+        }
+        let g_major_scale = [
+            Note::G4,
+            Note::A4,
+            Note::B4,
+            Note::C5,
+            Note::D5,
+            Note::E5,
+            Note::FSharp5,
+        ];
+        for _ in 0..3 {
+            for &n in &g_major_scale {
+                let _ = engine.harmonize_note_on(n);
+            }
+        }
+        let _ = engine.take_pending_releases();
+        // Second call must be empty — the queue is drained, not cloned.
+        assert!(engine.take_pending_releases().is_empty());
     }
 }

--- a/ui/src/lib/adapter/tauri.ts
+++ b/ui/src/lib/adapter/tauri.ts
@@ -32,7 +32,7 @@ import type {
  */
 function mapEngineState(raw: Record<string, unknown>, isRunning: boolean): EngineState {
 	return {
-		key: raw.key as string,
+		key: normalizeKey(raw.key as string),
 		mode: raw.mode as string,
 		modeNumber: raw.mode_number as number,
 		scaleMode: raw.scale_mode as string,
@@ -51,6 +51,23 @@ function mapEngineState(raw: Record<string, unknown>, isRunning: boolean): Engin
 }
 
 /**
+ * The Rust `Key` enum prints accidentals as flats (Db, Eb, Gb, Ab, Bb)
+ * but the UI's `KeyName` type uses sharps. Normalize so auto-key
+ * detector results map cleanly back to KeyName.
+ */
+const FLAT_TO_SHARP: Record<string, string> = {
+	Db: 'C#',
+	Eb: 'D#',
+	Gb: 'F#',
+	Ab: 'G#',
+	Bb: 'A#'
+};
+
+function normalizeKey(key: string): string {
+	return FLAT_TO_SHARP[key] ?? key;
+}
+
+/**
  * Maps the Tauri backend's snake_case NoteUpdatePayload to our camelCase NoteState.
  */
 function mapNoteState(raw: Record<string, unknown>): NoteState {
@@ -60,7 +77,7 @@ function mapNoteState(raw: Record<string, unknown>): NoteState {
 		borrowedNotes: raw.borrowed_notes as number[],
 		chordName: raw.chord_name as string,
 		lastBorrowedFrom: raw.last_borrowed_from as string,
-		currentKey: (raw.current_key as string) ?? 'C'
+		currentKey: normalizeKey((raw.current_key as string) ?? 'C')
 	};
 }
 


### PR DESCRIPTION
## Summary

- Tauri router thread ran a private snapshot of the harmony engine taken at routing-start. `state.engine` (mutated by `set_key`, `set_auto_key`, `set_mode`, ...) and the router's local engine diverged after that — mid-session parameter changes only updated the snapshot the UI read from, never the engine processing live MIDI.
- Auto-key was the most visible casualty (UI flipped to AUTO, engine kept harmonizing under the old key, no detection ever fired). Likely affected most other live param changes too.
- This PR shares one `Arc<Mutex<HarmonyEngine>>` across command handlers and the router thread, fixes a stuck-notes bug specific to auto-key changes, adds visibility logging, and normalizes Rust's flat key names to the UI's sharp key names.

## Changes

- **Shared engine.** `state.engine: Mutex<HarmonyEngine>` → `Arc<Mutex<HarmonyEngine>>`, cloned into the router thread instead of snapshotting an `EngineConfig` tuple. `process_midi_message` locks for the duration of one MIDI message; the 30 fps `note-update` emit briefly locks for `engine.key()` and `engine.last_borrowed_from()`.
- **Stuck-notes fix.** When auto-key fires `set_key` inside `harmonize_note_on`, `active_notes` is wiped and the previous key's harmonies stay sounding (the input note's later Note-Off only releases harmonies tracked under the new key). Added `pending_releases: Vec<Note>` populated before `set_key`, drained by the router via `take_pending_releases` so each stale harmony gets an explicit Note-Off before the new harmony Note-Ons go out.
- **`[AUTOKEY]` logging.** Toggle events and committed key changes log to stdout for debugging detector behavior.
- **UI key normalization.** Rust `Key` Display prints flats (`Db`, `Eb`, `Gb`, `Ab`, `Bb`) but the UI's `KeyName` type only has sharps. The `mapEngineState` and `mapNoteState` functions in the Tauri adapter map flats → sharps so detector results render in the key dropdown.

## Test plan

- [x] `cargo test --lib` — 536 passed, 1 ignored, 0 failed (3 new tests for the `pending_releases` wiring)
- [x] `cargo check --workspace` — clean
- [x] Manual: enabled auto-key, played C major → detector locked on C; modulated to G → detector flipped on the right note; UI dropdown updated to the new key (including for `Ab`/`Bb`/`Db`/`Eb`/`Gb`)
- [x] Manual: held a chord while auto-key triggered a key change — old harmonies released cleanly, no stuck notes
- [x] Manual: `set_key` / `set_mode` / `set_scale_mode` from the UI take effect on live MIDI mid-session (previously a no-op against the live engine)

## Known follow-ups

- Auto-key detector + modal interchange interaction. Borrowed notes shift the histogram and can confuse the detector — currently not weighted differently when interchange is on. Track separately.
- Detector tuning. Close-relative key transitions (C↔G, G↔D) sit inside the confidence margin and can feel laggy. Considered hysteresis + retuned constants in this PR but reverted to the original tuning after live testing felt better. Worth a real-music tuning pass in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)