### PR TITLE
fix(ci): copy crates/ in Dockerfile wasm-builder stage

### DIFF
--- a/crates/contrapunk-harmony/src/engine.rs
+++ b/crates/contrapunk-harmony/src/engine.rs
@@ -922,6 +922,114 @@ impl HarmonyEngine {
         }
     }
 
+    /// Octave-shift `harmony` so it lands on the correct side of `anchor`.
+    /// Returns None if no valid shift exists in MIDI range.
+    fn octave_shift_to_side(harmony: Note, anchor: Note, above: bool) -> Option<Note> {
+        let anchor_midi = u8::from(anchor) as i16;
+        let mut harm_midi = u8::from(harmony) as i16;
+        let on_correct_side = if above {
+            harm_midi > anchor_midi
+        } else {
+            harm_midi < anchor_midi
+        };
+        if on_correct_side {
+            return Some(harmony);
+        }
+        if above {
+            while harm_midi <= anchor_midi {
+                harm_midi += 12;
+                if harm_midi > 127 {
+                    return None;
+                }
+            }
+        } else {
+            while harm_midi >= anchor_midi {
+                harm_midi -= 12;
+                if harm_midi < 0 {
+                    return None;
+                }
+            }
+        }
+        Note::try_from(harm_midi as u8).ok()
+    }
+
+    /// Octave-shift block-voicing harmonies around `notes[0]` so the user's
+    /// note ends up at SATB slot `voice_position`. Used by block-voicing
+    /// modes (BarryHarris, FunctionalHarmony, BachChorale) which produce
+    /// a fixed voicing without natively respecting voice_position.
+    ///
+    /// Picks the closest-to-input harmonies to relocate. Also rewrites
+    /// `last_arrangement_indices` based on the post-shift pitch order so
+    /// downstream code (apply_octave_mode anchor logic, MIDI routing) sees
+    /// the correct SATB slot for each note.
+    fn redistribute_for_voice_position(&mut self, notes: &mut [Note]) {
+        if notes.len() <= 1 {
+            return;
+        }
+        let input_midi = u8::from(notes[0]) as i16;
+        let voice_position = self.voice_position;
+        // Number of harmonies that should sit above the user's note.
+        let target_above = voice_position.min(notes.len().saturating_sub(1));
+
+        let mut below_indices: Vec<usize> = Vec::new();
+        let mut above_indices: Vec<usize> = Vec::new();
+        for (i, n) in notes.iter().enumerate().skip(1) {
+            let m = u8::from(*n) as i16;
+            if m < input_midi {
+                below_indices.push(i);
+            } else if m > input_midi {
+                above_indices.push(i);
+            }
+        }
+        let cur_above = above_indices.len();
+
+        if cur_above < target_above {
+            // Promote closest-to-input below-harmonies (highest MIDI) up.
+            below_indices.sort_by_key(|&i| std::cmp::Reverse(u8::from(notes[i])));
+            for &i in below_indices.iter().take(target_above - cur_above) {
+                let mut new_midi = u8::from(notes[i]) as i16;
+                while new_midi <= input_midi {
+                    new_midi += 12;
+                    if new_midi > 127 {
+                        break;
+                    }
+                }
+                if (0..=127).contains(&new_midi) {
+                    if let Ok(n) = Note::try_from(new_midi as u8) {
+                        notes[i] = n;
+                    }
+                }
+            }
+        } else if cur_above > target_above {
+            // Demote closest-to-input above-harmonies (lowest MIDI) down.
+            above_indices.sort_by_key(|&i| u8::from(notes[i]));
+            for &i in above_indices.iter().take(cur_above - target_above) {
+                let mut new_midi = u8::from(notes[i]) as i16;
+                while new_midi >= input_midi {
+                    new_midi -= 12;
+                    if new_midi < 0 {
+                        break;
+                    }
+                }
+                if (0..=127).contains(&new_midi) {
+                    if let Ok(n) = Note::try_from(new_midi as u8) {
+                        notes[i] = n;
+                    }
+                }
+            }
+        }
+
+        // Rewrite arrangement_indices by post-shift pitch order: highest
+        // note → slot 0 (soprano), lowest → slot voice_count-1 (bass).
+        let mut order: Vec<usize> = (0..notes.len()).collect();
+        order.sort_by_key(|&i| std::cmp::Reverse(u8::from(notes[i])));
+        let mut arr = vec![0usize; notes.len()];
+        for (slot, &idx) in order.iter().enumerate() {
+            arr[idx] = slot;
+        }
+        self.last_arrangement_indices = arr;
+    }
+
     fn harmonize_block_chord(&mut self, note: Note) -> Vec<Note> {
         match super::barry_harris::build_voicing(note, &self.scale, self.beat_phase) {
             Some(voicing) => {
@@ -934,6 +1042,7 @@ impl HarmonyEngine {
                     }
                 }
                 self.last_arrangement_indices = (0..result.len()).collect();
+                self.redistribute_for_voice_position(&mut result);
                 self.apply_octave_mode(&mut result);
                 result
             }
@@ -956,7 +1065,7 @@ impl HarmonyEngine {
         let ctx = self
             .harmonic_context
             .get_or_insert_with(|| HarmonicContext::new(tonic, scale_mode));
-        let result = match self.mode {
+        let mut result = match self.mode {
             HarmonyMode::BachChorale => functional::bach_chorale(note, ctx, scale_mode),
             HarmonyMode::FunctionalHarmony => {
                 functional::functional_harmony(note, ctx, scale_mode, self.voice_count)
@@ -964,6 +1073,7 @@ impl HarmonyEngine {
             _ => vec![note],
         };
         self.last_arrangement_indices = (0..result.len()).collect();
+        self.redistribute_for_voice_position(&mut result);
         self.last_port_map = self.last_arrangement_indices.clone();
         result
     }
@@ -998,17 +1108,23 @@ impl HarmonyEngine {
             }
             HarmonyMode::StrictCounterpoint => {
                 // Species 1 is direction-aware via process_directed. Species 2-4
-                // rely on beat-phase and use the non-directed process path, so
-                // when a non-Species1 species is active we route through
-                // process_with_beat and ignore `above`.
+                // rely on beat-phase and use process_with_beat which ignores
+                // `above` — we octave-shift the result post-hoc to honor the
+                // chain's direction request.
                 let species = self.counterpoint_species;
                 let beat_phase = self.counterpoint_beat_phase;
                 if let Some(state) = self.counterpoint_states.get_mut(state_index) {
-                    if matches!(species, CounterpointSpecies::Species1) {
+                    let result = if matches!(species, CounterpointSpecies::Species1) {
                         state.process_directed(&mut self.scale, note, above)
                     } else {
                         state.process_with_beat(&mut self.scale, note, beat_phase)
+                    };
+                    if !matches!(species, CounterpointSpecies::Species1) && result.len() > 1 {
+                        if let Some(shifted) = Self::octave_shift_to_side(result[1], note, above) {
+                            return vec![note, shifted];
+                        }
                     }
+                    result
                 } else {
                     vec![note]
                 }
@@ -2224,6 +2340,86 @@ mod tests {
         assert!(
             above > 0 && below > 0,
             "voice_position=2 (tenor): expected harmonies both above and below input, got above={above} below={below}, full result={result:?}",
+        );
+    }
+
+    // --- block-voicing modes respect voice_position (fix #1) ---
+
+    #[test]
+    fn block_chord_bass_position_redistributes_voicing_above() {
+        // Barry Harris block voicing normally stacks below the melody.
+        // With voice_position=Bass, all harmonies must be above the input.
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::BarryHarris, 4);
+        e.set_voice_position(3); // bass
+        let result = e.harmonize_note_on(Note::C4);
+        if result.len() <= 1 {
+            return; // No voicing produced — depends on beat phase; not a regression
+        }
+        let input_midi = u8::from(Note::C4);
+        for (i, &n) in result.iter().enumerate().skip(1) {
+            let m = u8::from(n);
+            assert!(
+                m > input_midi,
+                "block-chord voice_position=3 (bass): result[{i}] = {m}, expected above input {input_midi}, full result={result:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn block_chord_alto_position_splits_around_input() {
+        // voice_position=alto in 4-voice → 1 above, 2 below.
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::BarryHarris, 4);
+        e.set_voice_position(1); // alto
+        let result = e.harmonize_note_on(Note::C4);
+        if result.len() <= 1 {
+            return;
+        }
+        let input_midi = u8::from(Note::C4);
+        let above = result[1..]
+            .iter()
+            .filter(|n| u8::from(**n) > input_midi)
+            .count();
+        assert_eq!(
+            above, 1,
+            "block-chord voice_position=1 (alto): expected exactly 1 above-input harmony, got {above}, full result={result:?}",
+        );
+    }
+
+    // --- counterpoint Species 2-4 honor direction (fix #1 cont.) ---
+
+    #[test]
+    fn counterpoint_species2_bass_position_harmony_above() {
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::StrictCounterpoint, 2);
+        e.set_counterpoint_species(CounterpointSpecies::Species2);
+        e.set_voice_position(1); // bass in 2-voice
+        e.set_counterpoint_beat_phase(Some(0.0));
+        let result = e.harmonize_note_on(Note::C4);
+        if result.len() <= 1 {
+            return;
+        }
+        let input_midi = u8::from(Note::C4);
+        let h = u8::from(result[1]);
+        assert!(
+            h > input_midi,
+            "Species2 voice_position=bass: harmony {h} should be above input {input_midi}, full result={result:?}",
+        );
+    }
+
+    // --- register-edge wrap (fix #2) ---
+
+    #[test]
+    fn chain_continues_at_low_register_edge() {
+        // User plays MIDI 1 (very low) as soprano in 4-voice. Chain below
+        // would land below MIDI 0 — pre-fix the chain broke and dropped
+        // voices; post-fix it wraps an octave to keep voices audible.
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 4);
+        e.set_voice_position(0); // soprano
+        let very_low = Note::try_from(1u8).unwrap();
+        let result = e.harmonize_note_on(very_low);
+        assert!(
+            result.len() >= 2,
+            "chain at register edge produced only {} note(s); expected the wrap fallback to keep voices, full result={result:?}",
+            result.len()
         );
     }
 }

--- a/crates/contrapunk-harmony/src/engine.rs
+++ b/crates/contrapunk-harmony/src/engine.rs
@@ -388,6 +388,10 @@ impl HarmonyEngine {
         if position == self.voice_position {
             return;
         }
+        println!(
+            "[VP] set_voice_position: {} (voice_count={})",
+            position, self.voice_count
+        );
         self.voice_position = position;
         self.active_notes.clear();
         self.active_port_maps.clear();
@@ -2169,5 +2173,57 @@ mod tests {
         let _ = engine.take_pending_releases();
         // Second call must be empty — the queue is drained, not cloned.
         assert!(engine.take_pending_releases().is_empty());
+    }
+
+    // --- voice_position chain direction tests ---
+
+    #[test]
+    fn voice_position_soprano_all_harmonies_below_input() {
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 4);
+        e.set_voice_position(0); // soprano = top
+        let result = e.harmonize_note_on(Note::C5);
+        let input_midi = u8::from(Note::C5);
+        for (i, &n) in result.iter().enumerate().skip(1) {
+            let m = u8::from(n);
+            assert!(
+                m < input_midi,
+                "voice_position=0 (soprano): result[{i}] = {m}, expected below input {input_midi}",
+            );
+        }
+    }
+
+    #[test]
+    fn voice_position_bass_all_harmonies_above_input() {
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 4);
+        e.set_voice_position(3); // bass = bottom
+        let result = e.harmonize_note_on(Note::C3);
+        let input_midi = u8::from(Note::C3);
+        for (i, &n) in result.iter().enumerate().skip(1) {
+            let m = u8::from(n);
+            assert!(
+                m > input_midi,
+                "voice_position=3 (bass): result[{i}] = {m}, expected above input {input_midi}",
+            );
+        }
+    }
+
+    #[test]
+    fn voice_position_tenor_harmonies_split_around_input() {
+        let mut e = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 4);
+        e.set_voice_position(2); // tenor = third from top in 4-voice
+        let result = e.harmonize_note_on(Note::C4);
+        let input_midi = u8::from(Note::C4);
+        let above = result[1..]
+            .iter()
+            .filter(|n| u8::from(**n) > input_midi)
+            .count();
+        let below = result[1..]
+            .iter()
+            .filter(|n| u8::from(**n) < input_midi)
+            .count();
+        assert!(
+            above > 0 && below > 0,
+            "voice_position=2 (tenor): expected harmonies both above and below input, got above={above} below={below}, full result={result:?}",
+        );
     }
 }

--- a/crates/contrapunk-harmony/src/modes.rs
+++ b/crates/contrapunk-harmony/src/modes.rs
@@ -163,6 +163,46 @@ pub fn random_below_no_seconds(note: Note, scale: &mut Scale) -> Vec<Note> {
 // When `above` is true, harmony is generated above the input note.
 // When `above` is false, harmony is generated below.
 
+/// Try `harmonize_smart`; if it would land out of MIDI range [0, 127],
+/// retry with the input octave-shifted toward the center of the range so
+/// the chain doesn't silently drop voices at register edges. Direction
+/// (above/below) is honored on the first attempt; the wrap fallback may
+/// land the harmony on either side of the input but keeps the voice
+/// audible — the harmonize() chain caller stitches results together by
+/// arrangement slot, not by pitch ordering.
+fn harmonize_smart_or_wrap(
+    scale: &mut Scale,
+    note: Note,
+    degrees: i8,
+    above: bool,
+) -> Option<Note> {
+    if let Some(h) = scale.harmonize_smart(note, degrees, above) {
+        return Some(h);
+    }
+    let m = u8::from(note) as i16;
+    // Try shifting input toward MIDI center (60). Order favors the shift
+    // direction that "undoes" the overflow: if we asked for above and
+    // failed, the harmony was too high — pull input down. If we asked for
+    // below and failed, pull input up.
+    let shifts: [i16; 4] = if above {
+        [-12, -24, 12, 24]
+    } else {
+        [12, 24, -12, -24]
+    };
+    for off in shifts {
+        let shifted = m + off;
+        if !(0..=127).contains(&shifted) {
+            continue;
+        }
+        if let Ok(shifted_note) = Note::try_from(shifted as u8) {
+            if let Some(h) = scale.harmonize_smart(shifted_note, degrees, above) {
+                return Some(h);
+            }
+        }
+    }
+    None
+}
+
 /// Directed diatonic thirds: above or below the input note.
 ///
 /// Used by [`super::HarmonyEngine`] for multi-voice generation where
@@ -170,7 +210,7 @@ pub fn random_below_no_seconds(note: Note, scale: &mut Scale) -> Vec<Note> {
 /// voice position.
 pub fn diatonic_thirds_directed(note: Note, scale: &mut Scale, above: bool) -> Vec<Note> {
     let interval = if above { 2 } else { -2 };
-    match scale.harmonize_smart(note, interval, above) {
+    match harmonize_smart_or_wrap(scale, note, interval, above) {
         Some(harmony) => vec![note, harmony],
         None => vec![note],
     }
@@ -179,7 +219,7 @@ pub fn diatonic_thirds_directed(note: Note, scale: &mut Scale, above: bool) -> V
 /// Directed diatonic fourths: above or below the input note.
 pub fn diatonic_fourths_directed(note: Note, scale: &mut Scale, above: bool) -> Vec<Note> {
     let interval = if above { 3 } else { -3 };
-    match scale.harmonize_smart(note, interval, above) {
+    match harmonize_smart_or_wrap(scale, note, interval, above) {
         Some(harmony) => vec![note, harmony],
         None => vec![note],
     }
@@ -198,7 +238,7 @@ pub fn random_directed(note: Note, scale: &mut Scale, above: bool) -> Vec<Note> 
     };
     let interval = intervals[rng.random_range(0..intervals.len())];
 
-    match scale.harmonize_smart(note, interval, above) {
+    match harmonize_smart_or_wrap(scale, note, interval, above) {
         Some(harmony) => vec![note, harmony],
         None => vec![note],
     }
@@ -217,7 +257,7 @@ pub fn random_no_seconds_directed(note: Note, scale: &mut Scale, above: bool) ->
     };
     let interval = intervals[rng.random_range(0..intervals.len())];
 
-    match scale.harmonize_smart(note, interval, above) {
+    match harmonize_smart_or_wrap(scale, note, interval, above) {
         Some(harmony) => vec![note, harmony],
         None => vec![note],
     }

--- a/crates/contrapunk-midi/src/output.rs
+++ b/crates/contrapunk-midi/src/output.rs
@@ -36,10 +36,9 @@ impl OutputRouter {
     /// - Any port index is invalid
     /// - Any connection fails
     pub fn new(port_indices: &[usize]) -> Result<Self> {
-        if port_indices.is_empty() {
-            return Err(anyhow!("No output ports specified"));
-        }
-
+        // Empty is allowed — voices may route entirely to the built-in synth
+        // via the per-voice routing table. Returning an empty router keeps
+        // the MIDI-output path no-op without blocking routing start.
         let mut connections = Vec::new();
 
         for (i, &idx) in port_indices.iter().enumerate() {

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 COPY wasm/ wasm/
+# Workspace-internal crates the root crate (and so the wasm crate) depend on.
+# These must be present in full because the wasm build pulls in their source.
+COPY crates/ crates/
 # Copy workspace member manifests so `cargo metadata` resolves (sources not needed for WASM build)
 COPY src-tauri/Cargo.toml src-tauri/Cargo.toml
 COPY plugin/Cargo.toml plugin/Cargo.toml

--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -660,8 +660,16 @@ fn handle_note_on(
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .clone();
-    let target_for =
-        |i: usize| -> VoiceOutputTarget { voice_targets.get(i).copied().unwrap_or_default() };
+    // The harmony engine returns notes as `[input, closest_harmony, ...]`
+    // — input always at index 0. To route each entry to the correct
+    // SATB voice slot (so e.g. the user's note plays through the
+    // tenor's output target when voice_position=2), we map result-Vec
+    // index → arrangement slot via the engine's port map.
+    let port_map: Vec<usize> = engine.last_port_map().to_vec();
+    let target_for = |i: usize| -> VoiceOutputTarget {
+        let slot = port_map.get(i).copied().unwrap_or(i);
+        voice_targets.get(slot).copied().unwrap_or_default()
+    };
 
     // Fan each voice into the built-in synth, gated by voice_outputs.
     for (i, &n) in notes.iter().enumerate() {
@@ -738,13 +746,18 @@ fn handle_note_off(
     let notes = engine.harmonize_note_off(note);
     let num_outputs = output.connection_count();
 
-    // Snapshot voice routing — same pattern as handle_note_on.
+    // Snapshot voice routing — same pattern as handle_note_on. Use the
+    // engine's port map so the per-voice routing slot matches the SATB
+    // arrangement (input note's slot follows voice_position, not 0).
     let voice_targets: Vec<VoiceOutputTarget> = voice_outputs
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .clone();
-    let target_for =
-        |i: usize| -> VoiceOutputTarget { voice_targets.get(i).copied().unwrap_or_default() };
+    let port_map: Vec<usize> = engine.last_port_map().to_vec();
+    let target_for = |i: usize| -> VoiceOutputTarget {
+        let slot = port_map.get(i).copied().unwrap_or(i);
+        voice_targets.get(slot).copied().unwrap_or_default()
+    };
 
     // Fan releases into the built-in synth only for voices routed there.
     for (i, &n) in notes.iter().enumerate() {

--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -349,15 +349,13 @@ fn run_tauri_router(
     let mut output_router = OutputRouter::new(output_ports)?;
     let num_outputs = output_router.connection_count();
 
-    // Sync voice_count to the number of routable outputs at the start of
-    // the session. All other engine parameters (key, mode, scale, voice
-    // leading, etc.) are user-driven and already live on `engine`; we
-    // share that instance with the Tauri command handlers so changes
-    // made during the session take effect on this routing pass.
-    {
-        let mut eng = engine.lock().unwrap_or_else(|e| e.into_inner());
-        eng.set_voice_count(num_outputs);
-    }
+    // voice_count is user-controlled via `set_voice_count`. With
+    // per-voice routing, voices in excess of the connected MIDI ports
+    // route to the built-in synth — there's no reason to clamp the
+    // engine's voice_count to `num_outputs` at routing start. (Doing
+    // so silently overrode the UI's voice picker — see the wave of
+    // "I picked soprano in a 4-voice setup but the engine had only
+    // 2 voices" reports.)
 
     // Event emission timer (~30fps)
     let mut last_emit = Instant::now();

--- a/ui/src/lib/stores/engine.svelte.ts
+++ b/ui/src/lib/stores/engine.svelte.ts
@@ -852,6 +852,12 @@ class EngineStore {
 		this.voiceCount = count;
 		try {
 			await adapter.setVoiceCount(count);
+			// Engine clamps voice_position to count-1 on shrink (e.g. 4→2 with
+			// position=Bass=3 ends up at position 1). Mirror that locally so
+			// the "You play" dropdown still matches a valid option.
+			if (this.voicePosition >= count) {
+				this.voicePosition = Math.max(0, count - 1);
+			}
 			this.persist();
 		} catch (e) {
 			this.voiceCount = prev;


### PR DESCRIPTION
The Fly.io deploy step started failing on main after the workspace
decomposition in #83. The wasm-builder stage in `deploy/Dockerfile`
was only `COPY`ing `src/` and `wasm/`, not the new `crates/` directory
that the root crate now depends on.

Error from the failed run:

\`\`\`
failed to load manifest for dependency \`contrapunk-audio\`
failed to read \`/app/crates/contrapunk-audio/Cargo.toml\`
No such file or directory (os error 2)
\`\`\`

Fix: add \`COPY crates/ crates/\` before the wasm-pack build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)