### PR TITLE
docs(planning): elixir synth — design decisions and research

### DIFF
--- a/.planning/notes/elixir-design-decisions.md
+++ b/.planning/notes/elixir-design-decisions.md
@@ -1,0 +1,96 @@
+---
+title: Elixir — load-bearing design decisions
+date: 2026-04-28
+context: Pre-design-doc Socratic exploration outcomes for the Elixir wavetable synth (open-source Serum clone in Rust, living inside contrapunk).
+---
+
+# Elixir — load-bearing design decisions
+
+Captured during `/gsd-explore` on 2026-04-28, after two parallel research streams landed:
+- `.planning/research/elixir/serum-features.md` — Serum feature inventory
+- `.planning/research/elixir/oss-prior-art.md` — OSS wavetable prior art + Rust plugin ecosystem
+
+These six decisions are the load-bearing constraints that the design doc must respect. Re-open them only with explicit reason; everything downstream is built on top.
+
+## 1. License posture — Elixir MIT/Apache, contrapunk stays MIT
+
+**Decision:** Elixir is permissive (MIT or Apache-2.0, exact choice in design doc). Contrapunk does not relicense to GPL.
+
+**Why:** Preserves contrapunk's permissive surface for any future downstream embedding. Elixir is a crate inside contrapunk's MIT workspace; both must be license-compatible.
+
+**Consequence (non-negotiable):** Every DSP technique must be **clean-room** — derived from papers, conference talks, public file-format specs, or BSD/MIT/Zlib/ISC code only. **No reading Vital, Vitalium, Surge XT, Helm, Odin 2, Bespoke, ZynAddSubFX, Dexed, or OB-Xd source code line-by-line.** Concepts and approaches discussed in talks/blog posts are fair; copy-paste of GPL code is not. Prior-art research file flags GPL boundaries.
+
+**How to apply:** When implementing DSP, cite the paper/talk/spec the implementation derives from in code comments. If a feature has no permissive prior art, it's clean-room from first principles or paper.
+
+## 2. Doc shape — architecture-complete, phased build
+
+**Decision:** Design doc specifies *every* Serum feature at the architecture level on day one. Implementation ships in phases. v1.0 is partial; subsequent versions grow into parity.
+
+**Why:** "All features from day one" + solo + clean-room is mathematically incompatible. Architecture-complete keeps the engine extensible (so we don't paint ourselves into a corner) while implementation is realistically staged.
+
+**How to apply:** Doc has a complete "Feature Architecture" section covering all 5 engines, 3-bus FX graph, full mod matrix, etc. A separate "Implementation Roadmap" section sequences delivery. Code structure must accommodate every future feature without major rewrite — e.g. `Engine` trait with WT impl shipped first, Spectral/Granular/Sample/Multisample as later impls of the same trait.
+
+## 3. "Better than Serum" axes — four named ambitions
+
+**Decision:** Elixir aims to *exceed* Serum on these four axes specifically. Other axes match Serum baseline, no more.
+
+1. **Audio quality + performance** — Lower aliasing, better filters, lower CPU per voice via Rust + SIMD, higher polyphony cap. Doc commits to specific quality/CPU benchmarks.
+2. **MPE / microtuning / MIDI 2.0 first-class** — Per-note expression as primary input model. ODDSound MTS-ESP (BSD-licensed) integrated from day one. MIDI 2.0 readiness in voice allocator. Serum's MPE is reportedly still maturing post-launch and MTS-ESP support is unconfirmed in any public source — clear lead opportunity.
+3. **Open & inspectable** — Human-readable native preset format (JSON or RON), scriptable mod graph (Lua/WASM/Rhai TBD in doc), themeable UI, fully documented file formats, public stable plugin API for extensions.
+4. **Tight contrapunk integration** — HarmonyEngine-aware modulation sources (scale/key as mod sources, harmony-driven preset variations, "harmonize-then-synthesize" as first-class). Direct Rust API access to contrapunk's harmony state — only possible because Elixir is a crate, not a black-box plugin.
+
+**Why:** These four were explicitly chosen by the user; the rest of Serum's surface is "match, don't exceed." This keeps ambition focused.
+
+**How to apply:** Each of these four axes gets a dedicated design doc section with concrete commitments (benchmarks for #1, MPE feature matrix for #2, schema for #3, mod-source list for #4).
+
+## 4. Code structure — engine crate + two shells
+
+**Decision:**
+- `crates/elixir-engine` — Pure Rust DSP/state crate. No UI. No plugin-shell dependencies.
+- Contrapunk integration: `AudioBlock` impl + Svelte UI (matches existing contrapunk synth pattern at `src/synth/voice.rs`).
+- `crates/elixir-plugin` — `nih-plug` CLAP/VST3 wrapper around the same engine, with vizia UI. This is the standalone build.
+
+**Why:** Contrapunk needs direct Rust API access for harmony-aware mod sources (decision #3.4) — a generic CLAP plugin host can't deliver that. Standalone needs a real plugin shell. One engine, two shells, two UIs serving two contexts.
+
+**How to apply:** Engine crate is the *only* place DSP and state live. Both shells consume the same public API. UI duplication is accepted cost.
+
+**Stack confirmed by research:**
+- `nih-plug` (ISC, Robbert van der Helm) for plugin shell — has shipped multiple production plugins; not GPL-tainted.
+- `vizia` for standalone GUI — recommended over `egui`/`iced` for dense Serum-class UI; uses Skia, supports custom-drawn knobs/wavetable views.
+- `iced` is fallback if vizia doesn't pan out.
+
+## 5. File-format compatibility — wavetables yes, presets gated
+
+**Decision:**
+- **Wavetables: full bidirectional read+write** for Serum's `clm`-chunk WAV format. ~100 LOC of Rust per the prior-art research. Free win.
+- **Native preset format**: Elixir defines its own human-readable format (JSON or RON, decided in doc). Aligns with "open & inspectable" ambition.
+- **Serum preset (`.SerumPreset`) reverse-engineering: deferred to post-MVP, gated.** Format is XferJson + zlib + undocumented binary blob; not publicly reverse-engineered. Xfer's EULA likely prohibits RE; legal posture varies by jurisdiction. See seed `elixir-serum-preset-re-gate.md` for trigger conditions and required gate before any public release.
+
+**Why:** Wavetable compat is technically trivial and legally clean. Preset compat is the opposite on both axes. Splitting them lets Elixir ship the marketing/UX win (Serum WT library "just works") without the risk.
+
+**How to apply:** Design doc commits to wavetable compat in v0; preset import is a placeholder labelled "post-MVP, see seed."
+
+## 6. Anti-aliasing strategy — Surge-style first, Vital-style as quality mode
+
+**Decision:** Mipmap pyramid built at wavetable load time (Surge XT approach) is the v1 anti-aliasing strategy. Vital-style frequency-domain harmonic storage with per-voice on-the-fly bandlimiting is documented as a future "quality mode."
+
+**Why:** Surge approach is battle-tested, low CPU, higher memory — best fit for solo first-implementation. Vital approach has higher quality ceiling but higher per-voice CPU and is more complex to get right. Both are well-documented in talks (Tytel ADC 2021 for the Vital approach; Surge XT's `wavetable.cpp` is GPL but the technique is generic and discussed in EarLevel articles).
+
+**How to apply:** Engine has an `AntiAliasStrategy` enum or trait so the second implementation slots in as a setting/quality mode rather than a rewrite.
+
+---
+
+## Open questions (tracked elsewhere, not blocking design doc)
+
+- Exact license: MIT vs Apache-2.0 vs dual MIT/Apache — decide in doc preamble.
+- Mod-graph scripting language: Lua vs WASM vs Rhai — discuss in doc.
+- Native preset format: JSON vs RON — minor; discuss in doc.
+- Plugin formats sequencing (CLAP-only first vs CLAP+VST3 day one) — decide when standalone shell phase is planned.
+
+## Pointers
+
+- Serum features: `.planning/research/elixir/serum-features.md`
+- OSS prior art + stack rationale: `.planning/research/elixir/oss-prior-art.md`
+- Contrapunk integration surface: see `src/chain/block.rs` (`AudioBlock` trait, lines 35–67), `src/synth/voice.rs` (existing synth as reference pattern), `src/harmony/engine.rs` (harmony source), `src-tauri/src/commands/` (Tauri command surface).
+- Pre-implementation reading list: `.planning/todos/pending/elixir-prereqs.md`
+- Preset RE gate: `.planning/seeds/elixir-serum-preset-re-gate.md`

--- a/.planning/research/elixir/oss-prior-art.md
+++ b/.planning/research/elixir/oss-prior-art.md
@@ -1,0 +1,85 @@
+# OSS Wavetable Synth Prior Art + Rust Plugin Ecosystem (research summary)
+
+**Status:** Summary captured from a research-agent run on 2026-04-28. The full long-form output was not preserved on disk; this file holds the agent's distilled findings. Re-run a deeper research pass if more granular per-project detail is needed.
+
+## Top design-critical takeaways
+
+### 1. License reality — every meaningful prior-art wavetable synth is GPLv3
+
+GPLv3 (or GPLv3-only): **Vital, Vitalium, Surge XT, Helm, Odin 2, Bespoke, ZynAddSubFX, Dexed, OB-Xd.**
+
+For a permissively-licensed Elixir, this means:
+- Read these projects only at the *concept* level. Do not copy code.
+- Clean-room derivation paths:
+  - Watch Tytel's ADC 2021 talk (concepts, not code).
+  - Read papers (Välimäki/Huovilainen on antialiasing oscillators).
+  - Read EarLevel articles (mipmap-pyramid wavetable construction).
+  - Implement against published file-format specs.
+- The Serum `clm`-chunk WAV format is openly documented; reimplementing the parser is permitted.
+
+### 2. Two viable anti-aliasing strategies — pick deliberately
+
+- **Vital approach:** frequency-domain harmonic storage + per-voice on-the-fly bandlimiting (Tytel ADC 2021).
+  - Best quality.
+  - Higher per-voice CPU.
+- **Surge XT approach:** mipmap pyramids computed at load time.
+  - Battle-tested.
+  - Low CPU.
+  - Higher memory.
+
+**Recommendation:** ship Surge-style mipmap first; add Tytel-style as a quality mode later. (Confirmed in the design decisions note.)
+
+### 3. `nih-plug` is the right plugin shell
+
+- Author: Robbert van der Helm.
+- License: ISC (permissive — license-compatible with Elixir).
+- Exports CLAP + VST3.
+- Has shipped multiple production plugins (`Spectral Compressor`, `Diopser`, etc. in its `plugins/` directory).
+- Sample-accurate automation.
+- Provides adapters for **vizia / iced / egui** GUI frameworks.
+
+### 4. GUI — `vizia` is the strongest pick for Serum-class dense UI
+
+- Uses Skia for rendering.
+- Supports custom-drawn knobs and wavetable views.
+- Recommended over egui in nih-plug docs for plugin UIs.
+- **Iced** is the fallback (more mature ecosystem; `iced_audio` widget pack exists).
+- **egui** is fine for a debug overlay but not the production UI.
+
+### 5. Serum WAV format is an implementable de-facto standard
+
+- 32-bit float WAV.
+- 2048-sample frames per cycle.
+- ASCII `clm ` chunk encodes metadata: `<!>2048 BC000000 vendor` (or similar — verify exact byte pattern when implementing).
+- Read by: Vital, Pigments, Korg modwave, Surge, Ableton Wavetable.
+- Implementation: ~100 lines of Rust to parse and serialize.
+
+**Decision implication:** implement this importer/exporter first. Skip Serum `.fxp` and `.SerumPreset` import (proprietary, not publicly RE'd — see seed `elixir-serum-preset-re-gate.md`).
+
+## Single must-do before writing any oscillator code
+
+Watch and take notes on:
+- **Matt Tytel — "Practical Guide to Optimized High-Quality Wavetable Oscillators" (ADC 2021)**
+  - Video: https://www.youtube.com/watch?v=qlinVx60778
+  - Slides: https://data.audio.dev/talks/2021/guide-to-optimized-wavetable-oscillators/slides.pdf
+
+For Surge-style mipmap implementation, read EarLevel's wavetable series:
+- https://www.earlevel.com/main/2012/05/04/a-wavetable-oscillator%E2%80%94introduction/
+
+## Stack — recommended set
+
+| Layer | Pick | License | Notes |
+|---|---|---|---|
+| Plugin shell (standalone) | `nih-plug` | ISC | CLAP + VST3 export |
+| GUI (standalone) | `vizia` | MPL-2.0 | Custom knob/WT rendering |
+| GUI fallback | `iced` + `iced_audio` | MIT | If vizia ergonomics fail in spike |
+| DSP primitives | `fundsp` / `dasp` | MIT/Apache | Evaluate; may roll our own |
+| Audio I/O (standalone host) | `cpal` | Apache/MIT | Already used by contrapunk |
+| Microtuning | ODDSound MTS-ESP | BSD | C library, FFI via bindgen |
+
+## Open follow-ups
+
+- Spike `nih-plug` + `vizia` "hello sine" plugin in Reaper / Bitwig CLAP.
+- Survey `fundsp` and `dasp` for what we can pull in vs. write ourselves.
+- Confirm Rust binding strategy for ODDSound MTS-ESP (`bindgen` vs hand-written FFI).
+- Identify the closest publicly-permissively-licensed reference implementation for each Serum feature area (oscillators, filters, FX, mod matrix) — most will be from-paper, no reference impl.

--- a/.planning/research/elixir/serum-features.md
+++ b/.planning/research/elixir/serum-features.md
@@ -1,0 +1,66 @@
+# Serum — Feature Inventory (research summary)
+
+**Status:** Summary captured from a research-agent run on 2026-04-28. The full long-form output was not preserved on disk; this file holds the agent's distilled findings. **Re-run a deeper research pass before locking the design doc** if more granular detail is needed (manual deep-dive, exhaustive parameter list, etc.).
+
+## Top design-critical findings
+
+### 1. Serum is a five-engine hybrid, not a wavetable synth
+
+Each of OSC A / OSC B / OSC C independently selects between:
+- **Wavetable** (the classic Serum engine)
+- **Multisample** (SFZ-style)
+- **Sample** (single-sample playback)
+- **Granular**
+- **Spectral** (real-time STFT resynthesis, partial tracking, transient detection, PNG-image-as-spectrum import)
+
+**Architectural implication for Elixir:** the engine layer must abstract over an `Engine` trait from day one. The Spectral engine alone is a significant DSP undertaking (estimated 30–50% of total DSP effort).
+
+### 2. Preset format change — `.SerumPreset`, not `.fxp`
+
+- Header: XferJson (trivially parseable).
+- Body: zlib-compressed undocumented binary blob.
+- **Not publicly reverse-engineered.**
+- Serum 1 `.fxp` is also only partially documented.
+- Wavetable format (`.wav` + `clm ` ASCII chunk) is **fully open and reimplementable** — a free compatibility win.
+
+### 3. Modulation scope is larger than headlines
+
+- **10 LFOs** (with Path mode producing dual X/Y outputs → ~20 effective streams).
+- **4 envelopes.**
+- **8 macros.**
+- Per-mod-slot remap curves with curve-preset saving.
+- Closer in capability to Vital / Phase Plant than to Serum 1.
+
+(Conflict in sources: gearnews says 6 LFOs; Sonic Weaponry / Databroth / EDMProd / Star Samples all say 10. Going with **10**.)
+
+### 4. FX is a 3-bus parallel graph
+
+- Three independent FX buses, multiple instances allowed.
+- Splitter modules: L/H, L/M/H, M/S.
+- This is a fundamentally different graph topology from Serum 1's single linear chain.
+- **Architectural implication:** Elixir's FX module needs a graph engine, not a list — must support arbitrary parallel sub-chains from day one.
+
+### 5. MPE and microtuning are weaponizable gaps
+
+- Serum's own MPE is reportedly still maturing post-launch.
+- **MTS-ESP support is unconfirmed** in any public source consulted.
+- Dropping in ODDSound's BSD-licensed MTS-ESP library plus a properly-designed MPE voice allocator from day one would let Elixir leapfrog Serum on expression and microtonal use cases.
+
+## Open follow-ups
+
+- Get the Serum manual when next available and produce an exhaustive parameter table.
+- Confirm filter model list (LP/HP/BP/notch/comb/formant/MS-20-style/OB-style/etc.).
+- Confirm exact FX module list and routing semantics.
+- Capture Serum's UI panel layout (high-level prose, no copyrighted imagery).
+- Verify polyphony cap, mono/legato/glide modes, microtuning support, MPE modes.
+
+## Sources consulted (per agent report)
+
+- xferrecords.com (official Serum page)
+- Sonic Weaponry overview
+- Databroth feature breakdown
+- EDMProd review
+- Star Samples writeup
+- gearnews announcement (conflicts noted above)
+
+A subsequent research pass should cite each claim against a source URL.

--- a/.planning/seeds/elixir-serum-preset-re-gate.md
+++ b/.planning/seeds/elixir-serum-preset-re-gate.md
@@ -1,0 +1,52 @@
+---
+title: Elixir — Serum preset reverse-engineering gate
+trigger_condition: After Elixir's wavetable engine and modulation matrix are stable (post-MVP, likely v0.3+), AND user is ready to invest in Serum preset import as a feature.
+planted_date: 2026-04-28
+---
+
+# Serum preset RE — gated future work
+
+The user has expressed intent to reverse-engineer Serum's `.SerumPreset` format for full bidirectional preset compatibility. This is **gated work** — do not start until the trigger conditions are met AND the gate below is fully passed.
+
+## Why gated
+
+- **Format is closed and unreversed.** Per `.planning/research/elixir/serum-features.md`, `.SerumPreset` = XferJson header + zlib-compressed undocumented binary blob. No public spec exists.
+- **Legal risk varies by jurisdiction.** Xfer's EULA almost certainly prohibits reverse engineering. Some jurisdictions (EU under the Software Directive, US under DMCA §1201(f) for interoperability) carve out RE-for-interoperability with limits; others don't. Litigation risk is non-zero even where legally defensible.
+- **Effort is significant.** Solo, undocumented binary format, brittle long-term as Serum updates. Easy to spend months for marginal user value (most users care more about wavetable compat — already covered).
+- **Premature work.** Until the engine itself can faithfully *reproduce* what a Serum preset describes (all 5 engines, full mod matrix, 3-bus FX graph), an importer has nothing to import *into*.
+
+## Trigger conditions (all must be met)
+
+- [ ] Elixir wavetable engine is stable and producing audio comparable to Serum.
+- [ ] Modulation matrix supports the full Serum feature surface (10 LFOs, 4 envs, 8 macros, mod slot remap curves).
+- [ ] FX graph supports the 3-bus parallel topology with splitter modules.
+- [ ] User explicitly decides preset import is the next priority over other backlog items.
+
+## Gate (must complete BEFORE any RE work begins)
+
+1. **Clean-room methodology document.** Specify how RE will be performed:
+   - No disassembly of Serum binaries.
+   - No use of debuggers attached to running Serum.
+   - File-format-only analysis: hex dumps, statistical analysis, comparison of preset files saved with controlled parameter changes.
+   - One person observes Serum behavior and writes specs in English; a separate person (or separate work session, with a deliberate gap) implements against those specs only. Document this separation.
+2. **Jurisdictional analysis.** Document the user's jurisdiction (USA / EU / other) and the applicable RE-for-interop carve-outs. Capture the specific legal basis being relied on.
+3. **EULA review.** Read Serum's current EULA. Document the specific clauses relevant to RE and the user's interpretation of them.
+4. **Legal review (recommended).** Have an IP attorney review the methodology document, jurisdictional analysis, and EULA review before any RE begins. Document their feedback in writing.
+5. **Risk acceptance.** User explicitly accepts residual risk in writing (commit to this seed file or a successor doc) before work starts.
+
+## Implementation guardrails (when work begins)
+
+- All RE work happens in a **separate, clearly-marked branch and crate** (e.g. `crates/elixir-serum-import`) so the import code can be removed/disabled if legal posture changes.
+- Importer is **read-only** — Elixir does not write `.SerumPreset` files (that would be authoring proprietary format, not interop).
+- Importer is **lossy and warns** — clearly tell users when params can't be mapped. Don't pretend to fully reproduce a Serum preset; produce an Elixir preset that approximates one.
+- Distribution decision: shipping importer in default builds vs. as opt-in feature flag is its own gate. Default to feature-flagged.
+
+## Alternative if gate cannot be passed
+
+Stay on wavetable-compat-only path. Users can re-create presets manually using Elixir's native format. The "open & inspectable" ambition arguably wins more hearts than risky preset import anyway.
+
+## Pointers
+
+- Format research: `.planning/research/elixir/serum-features.md` (preset format section)
+- Wavetable format (already permitted, not gated): `.planning/research/elixir/serum-features.md` (wavetable section)
+- Original decision context: `.planning/notes/elixir-design-decisions.md` (decision #5)

--- a/.planning/todos/pending/elixir-prereqs.md
+++ b/.planning/todos/pending/elixir-prereqs.md
@@ -1,0 +1,51 @@
+---
+title: Elixir — pre-implementation reading & evaluation list
+date: 2026-04-28
+priority: high
+---
+
+# Elixir — pre-implementation prerequisites
+
+Concrete tasks to complete **before writing any oscillator code**. Clean-room implementation under permissive license requires a paper-trail of derivation sources; doing the reading first prevents inadvertent GPL contamination and avoids the rewrite tax of building on the wrong foundation.
+
+## DSP foundations (must-read before WT engine code)
+
+- [ ] **Watch:** Matt Tytel — "Practical Guide to Optimized High-Quality Wavetable Oscillators" (ADC 2021).
+  - Video: https://www.youtube.com/watch?v=qlinVx60778
+  - Slides: https://data.audio.dev/talks/2021/guide-to-optimized-wavetable-oscillators/slides.pdf
+  - Why: defines modern state of the art for wavetable anti-aliasing and the technique behind Vital. Take notes; we're implementing the *concepts*, not the code.
+- [ ] **Read:** Nigel Redmon's EarLevel wavetable series (multi-part): https://www.earlevel.com/main/2012/05/04/a-wavetable-oscillator%E2%80%94introduction/
+  - Why: clearest public explanation of mipmap-pyramid wavetable construction (Surge XT's approach, our v1 strategy).
+- [ ] **Read:** Välimäki & Huovilainen — "Antialiasing Oscillators in Subtractive Synthesis" (IEEE Signal Processing Magazine, 2007).
+  - Why: BLEP/MinBLEP background for non-wavetable oscillator types and reference filter quality.
+- [ ] **Read:** Will Pirkle — "Designing Software Synthesizer Plug-Ins in C++" (relevant chapters on filter topologies, ADSR shapes, mod matrix).
+  - Why: textbook treatment of synth architecture; useful as a vocabulary baseline even though the code examples are GPL-incompatible to copy.
+
+## File-format specs (before file I/O code)
+
+- [ ] **Document:** Serum wavetable WAV `clm` chunk format. The prior-art research file has a partial spec; expand into a standalone `docs/wavetable-format.md` so the parser can be built from a written spec, not from another implementation.
+- [ ] **Survey:** existing public docs/notes on the format (Vital wiki, KVR threads, modwave docs). Cite all sources in the doc.
+- [ ] **Defer (do NOT start yet):** Serum `.SerumPreset` format. Gated by seed `elixir-serum-preset-re-gate.md`. No work until trigger conditions are met.
+
+## Stack evaluation (before crate skeleton)
+
+- [ ] **Build a "hello sine" with `nih-plug` + `vizia`** as a throwaway spike. Goal: confirm plugin loads in a real DAW (Reaper / Bitwig CLAP), confirm vizia renders a custom-drawn widget at 60fps. Estimated 1–2 days. If vizia struggles with custom rendering or the toolchain is rough, fall back to `iced` + `iced_audio` (also evaluated in this spike).
+- [ ] **Survey:** `fundsp` and `dasp` for DSP primitives we can pull in vs. write ourselves. Note their licenses and quality bar.
+- [ ] **Survey:** ODDSound MTS-ESP integration in Rust. Library is BSD-licensed but written in C — confirm Rust binding strategy (`bindgen` vs hand-written FFI).
+
+## Architecture spike (before design doc finalization)
+
+- [ ] **Sketch:** voice graph data structure. Per-voice mod evaluation order: per-sample vs. per-block, how the mod matrix is wired, where SIMD applies. One page of pseudocode is enough.
+- [ ] **Sketch:** `Engine` trait that accommodates all five Serum engine types (Wavetable, Multisample, Sample, Granular, Spectral). Confirm trait signature doesn't break when engines beyond WT are added later.
+- [ ] **Sketch:** 3-bus FX graph topology (parallel sub-chains, splitter modules). Confirm whether existing contrapunk `Chain` abstraction (`src/chain/chain.rs`) can host this or whether Elixir needs its own internal FX graph.
+
+## Contrapunk integration audit
+
+- [ ] **Read:** `src/chain/block.rs` (lines 35–67) — `AudioBlock` trait, the integration point.
+- [ ] **Read:** `src/synth/voice.rs` — existing 8-voice polyphonic synth as a reference pattern. Understand how it gets MIDI events and how its parameters are exposed via Tauri commands.
+- [ ] **Read:** `src/harmony/engine.rs` (lines 30–100) — public API of HarmonyEngine. Identify what state we'd need to expose to Elixir as harmony-aware mod sources.
+- [ ] **Decide:** Tauri command naming conventions for Elixir parameters (likely `elixir_*` prefix — confirm with existing `set_synth_*` patterns).
+
+## Outcome
+
+When all boxes are checked, the design doc can be written with confidence and the engine crate skeleton can be created without rework. Estimated total: 1–2 weeks of part-time prep.


### PR DESCRIPTION
## Summary
- Captures `/gsd-explore` exploration outcomes for **Elixir** — an open-source wavetable synth in Rust, planned to live as a crate inside contrapunk and also ship as a standalone plugin.
- Six load-bearing decisions locked: license posture, doc shape, ambition axes, code structure, file-format compat policy, anti-aliasing strategy.
- Two research summaries (reference-synth feature inventory, OSS prior art + Rust plugin ecosystem), pre-implementation prereqs todo, gated seed for any future preset reverse-engineering work.

## Files added
- `.planning/notes/elixir-design-decisions.md`
- `.planning/research/elixir/serum-features.md`
- `.planning/research/elixir/oss-prior-art.md`
- `.planning/seeds/elixir-serum-preset-re-gate.md`
- `.planning/todos/pending/elixir-prereqs.md`

## Test plan
- [ ] No code changes; CI fmt/clippy/check/test/wasm/tauri/frontend should pass unchanged.
- [ ] Verify the five new `.planning/` files render correctly on GitHub.