### PR TITLE
feat: performance view + diff-based reharmonization + continuous Spread

### DIFF
--- a/.planning/PERFORMANCE-VIEW-USER-TESTING.md
+++ b/.planning/PERFORMANCE-VIEW-USER-TESTING.md
@@ -1,0 +1,109 @@
+# Performance View — Pre-Build User Testing Plan
+
+A 30-minute session to validate (or invalidate) the design assumptions in `PERFORMANCE-VIEW.md` against a real non-musician *before* committing engineering effort. Run with the **current** Contrapunk UI (not the future Performance view) — the goal is to find out where the existing UI breaks down for the target audience.
+
+## Goal
+
+Diagnose where non-musicians actually stall in the current ~40-control UI. Validate that the brutal-critic findings reflect real user behavior rather than reviewer-grade nitpicks. Pin down which problems are *naming* (knobs make sense, labels don't), which are *count* (too many controls), and which are *defaults* (initial state hides the value prop).
+
+## Recruit profile
+
+Ideal: someone who likes music, can identify a song, has tried a music-making app once, but can't tell you what a "diatonic third" is. A hobbyist guitarist or singer who plays for fun. Not a producer, not a music-theory student. One person is enough for v1; this is qualitative, not statistical.
+
+## Setup (before they arrive)
+
+- Laptop running the current Contrapunk app
+- App in default cold-start state (close it and reopen so they get the genuine first-launch experience)
+- Audio output working through laptop speakers or headphones
+- A MIDI keyboard plugged in if available; if not, the Computer Keyboard input works
+- Screen recording on (with their consent) so you can review pause/hesitation moments later
+- A timer visible to you (not them)
+
+## Session protocol
+
+**Don't coach. Don't explain music theory. Don't narrate the UI. Just observe.** If they ask "what does this do?" — write it down, then say *"What do you think it does?"* — you're trying to find out where the UI fails to teach itself.
+
+### Phase 1: Cold open (5 min)
+
+Hand them the laptop, app already running. Say:
+
+> *"This app generates backing harmonies when you play or sing a note. Try to make it produce some harmony."*
+
+Then stop talking. Watch.
+
+**Observations to capture:**
+- Time to first audible harmony note (or give-up)
+- Whether they find Start before trying to play
+- What they tried first (which control did they touch?)
+- What they said out loud
+- Whether they discovered that the default mode (`PassThrough`) is silent
+- Whether they hear the Internal Synth at all (it's pre-routed but not visible)
+
+### Phase 2: Tasks (15 min)
+
+Give them these tasks one at a time. Don't move on until they either complete or explicitly give up. Write down time-to-complete for each.
+
+| # | Task | What it actually exercises |
+|---|---|---|
+| 1 | "Make the harmony thicker — more voices." | `voiceCount` discoverability |
+| 2 | "Change the style of the harmony — make it sound different." | `mode` picker + label comprehensibility |
+| 3 | "Try to make it sound sad or moody." | scale-mode + key-mode selection |
+| 4 | "Set this to play in the key of A." | Key picker + auto-key interaction |
+| 5 | "Save this exact sound so you can come back to it later." | Save/recall (currently impossible — observe how they look for it) |
+| 6 | "Make the harmony come from above your note instead of below." | `voicePosition` (the "You play" picker) |
+| 7 | "Make this sound less random and more controlled." | Voice-leading toggle + style selection |
+
+For each task, capture:
+- Did they complete it? (yes / partial / gave up)
+- What was their first attempt?
+- What labels did they search for that didn't exist?
+- What jargon stopped them cold?
+- How many controls did they touch on the way?
+
+### Phase 3: Reactions (5 min)
+
+After all tasks, ask these in order. Write down their words verbatim where possible.
+
+1. *"What was the most confusing thing about using this?"*
+2. *"What did you expect to find that wasn't there?"*
+3. *"Were there any words on the screen you didn't understand?"* (point if needed)
+4. *"If you were going to use this in a band, what's missing?"*
+5. *"What sound did you make that you actually liked? Could you make it again?"*
+
+### Phase 4: Brief reveal (5 min)
+
+Show them the `PERFORMANCE-VIEW.md` 8-knob mock-up (verbally describe if no mock exists yet):
+> *"We're considering replacing this with 8 knobs: Mode, Voices, Tightness, Adventurous, Key, Scale, You-play, Spread. Plus the harmony you just made would be remembered when you reopen the app, but there's no explicit Save button. Does that sound better, worse, or the same?"*
+
+Capture their gut reaction. Probe specifically:
+- Is "Tightness" a word they'd intuit?
+- Does "Adventurous" parse as a music control?
+- Are they upset about no Save button, or relieved by fewer controls?
+
+## Specific moments to watch for
+
+- **The cold-start silence** (default mode = PassThrough). Do they think the app is broken? How long before they realize they need to change something to hear anything?
+- **The Auto-key dropdown bug** (clicking Key while AUTO is on silently disables it). Do they hit it? Do they notice?
+- **The 4-vs-8 voice-count mismatch** (UI clamps at 4 even though engine supports 8). Do they want more voices than the picker allows?
+- **The Counterpoint Species card** (appears when they pick Strict Counterpoint). What's their face when they see "Species 2 (2:1)" and "Strictness: Relaxed/Strict"?
+- **The PassThrough bypass moment** — first time they choose a mode that produces audible harmony. How did they find it? What was their reaction?
+- **The "You play" picker** — do they understand "Soprano (1)" vs "Bass (4)" vocabulary, or do they ignore the control entirely?
+
+## After the session
+
+Within 24 hours, write a 1-page observation summary. Include:
+
+- 5 things they got stuck on, ranked by how much time they lost
+- 3 specific labels / words they couldn't parse
+- 1 task they fully gave up on (likely Task 5: save/recall)
+- Their gut reaction to the 8-knob redesign reveal
+- Any design assumptions in `PERFORMANCE-VIEW.md` that this session disproved
+
+If their behavior matches what `PERFORMANCE-VIEW.md` predicts, build it. If they got stuck somewhere we didn't anticipate, revise the doc before building.
+
+## Anti-patterns
+
+- Don't run this with a music producer. They'll succeed at every task and tell you the UI is fine.
+- Don't run this with the developer team. They know where everything is.
+- Don't ship the brutal-critic findings to the test subject before the session. You want their fresh reactions, not validations of someone else's analysis.
+- Don't watch one user, conclude "the redesign is right," and stop. One user invalidates assumptions; multiple users (3-5) validate them. v1 of this plan asks for one because going from zero validation to one is the highest-leverage step; further runs only matter if the first one's findings surprise you.

--- a/.planning/PERFORMANCE-VIEW.md
+++ b/.planning/PERFORMANCE-VIEW.md
@@ -1,0 +1,478 @@
+# Performance View — Design Notes
+
+A simplified, switchable UI view alongside the existing detailed UI. Targets musicians (especially non-experts) who currently find Contrapunk's ~40-control surface unusable. The existing UI stays as the "Advanced" view; users toggle between them. The previous view-mode infrastructure was deleted in favor of per-panel pips, so the switcher needs to be built fresh.
+
+## Design principle
+
+Every knob in this view passes the test: *"Is this something the user touches WHILE playing?"* If not, it's a pad / setting / advanced-only.
+
+## The 8 knobs
+
+| # | Knob | Type | Maps to |
+|---|---|---|---|
+| 1 | **Mode** | 5 detents (ordered spectrum) | `HarmonyMode` enum |
+| 2 | **Voices** | 1-8 detents | `voice_count` |
+| 3 | **Tightness** | continuous 0..1 | composite: `voice_leading_*` + `counterpoint_*` |
+| 4 | **Adventurous** | continuous 0..1 | composite: `interchange_enabled` + `borrowing_range` |
+| 5 | **Key** + Auto toggle | 12 detents + on/off | `key`, `auto_key` |
+| 6 | **Scale** | 5-7 category detents | `scale_mode` (with default sub-mode per category) |
+| 7 | **You play** | 1-N detents (N = voice count) | `voice_position` |
+| 8 | **Spread** | continuous 0..1 | quantized `OctaveMode` (v1) → continuous (v2) |
+
+**Detune dropped from Performance view** — pure texture with no live-performance value. Moves to Setup pane / synth stage.
+
+## Mode spectrum
+
+```
+Off  →  Parallel 3rds  →  Parallel 4ths  →  Contrary  →  Functional
+ 0          1                  2                3              4
+```
+
+5 detents, ordered by harmonic sophistication / voice independence. User can sweep through this live for dynamic effect.
+
+Engine mapping:
+
+| Detent | `HarmonyMode` |
+|---|---|
+| 0 | `PassThrough` |
+| 1 | `DiatonicThirds` |
+| 2 | `DiatonicFourths` |
+| 3 | `ContraryMotion` |
+| 4 | `FunctionalHarmony` |
+
+### Dropped from this view
+
+- **`RandomBelow`** — nondeterministic, untrustworthy live. Variation moves to Adventurous knob (interchange-based, deterministic).
+- **`RandomBelowNoSeconds`** — same reason.
+- **`BarryHarris`** — scale-specific (only sensible in BH 6th-diminished scales). Stays in advanced view; could re-enable in Performance view conditionally when the active scale family is `BarryHarris`.
+- **`BachChorale`** — promoted to an emergent unlock (see below).
+- **`StrictCounterpoint`** (Species 1-4) — folded into Tightness=high. Stays in advanced view with full species/strictness controls.
+
+## Composite-knob mappings
+
+### Tightness
+
+| Range | Underlying behavior |
+|---|---|
+| 0.0–0.3 | `voice_leading_enabled = false` |
+| 0.3–0.7 | `voice_leading_enabled = true`, `voice_leading_style = Free` |
+| 0.7–0.9 | `voice_leading_style = Smooth` (or Jazz / BachChorale-flavored, depending on Mode) |
+| 0.9–1.0 | When Mode = Functional → BachChorale voicing rules. When Mode = Contrary → StrictCounterpoint, Species 1, Strictness=Strict. Otherwise → strictest applicable voice-leading style. |
+
+Exact ranges/curves TBD by sound testing.
+
+### Adventurous
+
+| Range | Underlying behavior |
+|---|---|
+| 0.0 | `interchange_enabled = false` |
+| 0.0–1.0 | `interchange_enabled = true`, `borrowing_range = clamp(round(value × 7), 1, 7)` |
+
+### Spread (continuous OctaveMode)
+
+**v1** (cheap path) — quantize knob into 4 zones mapping to existing `OctaveMode` enum:
+
+| Range | OctaveMode |
+|---|---|
+| 0.0–0.25 | `None` |
+| 0.25–0.5 | `Spread` |
+| 0.5–0.75 | `BassTrebleSplit` |
+| 0.75–1.0 | `Mirror` |
+
+**v2** (proper) — true continuous spread coefficient applied per-voice in the engine. Larger refactor; not required for v1.
+
+### Scale (categorical, 8 detents)
+
+The engine's `scale_mode` enum has ~30 sub-modes. Performance view collapses these to 8 category detents; sub-mode within a category is set by per-category default (or last-used), with full picker available in Advanced view.
+
+**Ordering principle: simplest / hardest-to-misuse first.** Detent 1 should be the safest landing spot for a non-musician — the scale where "no notes are wrong." That's Pentatonic. Each subsequent detent introduces more harmonic complexity that the user needs to know how to handle.
+
+| Detent | Category | Default sub-mode | Tonal? |
+|---|---|---|---|
+| 1 | **Pentatonic** | Major Pentatonic | partial — no 4 or 7, can't really hit a wrong note |
+| 2 | **Major** | Ionian | yes |
+| 3 | **Natural Minor** | Aeolian | yes |
+| 4 | **Harmonic Minor** | Harmonic Minor | yes (strong dom-V via raised 7) |
+| 5 | **Melodic Minor** | Melodic Minor | yes |
+| 6 | **Modal** | Dorian (sub-cycle to Phrygian / Lydian / Mixolydian / Locrian in Advanced) | yes |
+| 7 | **World** | Pelog | no |
+| 8 | **Symmetric** | Whole Tone | no |
+
+**Default on first launch:** Pentatonic. Cold-start user plays anything and the harmony sounds good — that's the value proposition the brutal-critic UI review said was hidden behind 3 setting changes today.
+
+Harmonic Minor and Melodic Minor are split out from "Minor" because they sound fundamentally different — the raised 7 in Harmonic Minor produces strong V-i resolutions and the iconic augmented 2nd from b6 to 7; Melodic Minor (raised 6 and 7 ascending) is the basis of much modern jazz harmony. Lumping them under one category loses too much.
+
+The "Tonal?" column gates which Mode + Tightness + Adventurous unlocks can fire (see updated tree below). Non-tonal scales (World, Symmetric) work fine with Parallel/Contrary modes; Functional/Chorale unlocks suppress because there's no functional harmony to chord-tone against.
+
+Sub-mode access in Advanced view exposes each category's full mode list:
+- Major → Ionian (only)
+- Natural Minor → Aeolian (only)
+- Harmonic Minor → Harmonic Minor + its 7 modes (Phrygian Dominant, Lydian #2, etc.)
+- Melodic Minor → Melodic Minor + its 7 modes (Lydian Dominant, Altered, Locrian #2, etc.)
+- Modal → Dorian / Phrygian / Lydian / Mixolydian / Locrian
+- Pentatonic → Major / Minor / Hirajoshi / InSen / Iwato / Yo / Kumoi
+- World → Pelog / Slendro / Hijaz / Hungarian / Persian / etc.
+- Symmetric → Whole Tone / Diminished / Chromatic
+
+### Key (with Auto-key toggle)
+
+The Key knob has an attached Auto/Manual toggle pip:
+
+- **Auto = on**: Key knob is read-only and *displays* the engine's currently-detected key with a "live" indicator. Engine drives `key` via `auto_key` detection from input.
+- **Auto = off**: User sets key manually via the knob. `auto_key = false`, `key = user_choice`.
+- **Grabbing the Key knob while Auto is on**: explicitly disables Auto with a visible state change (toggle pip flips, brief toast: *"Manual key set — auto-key disabled"*). Fixes the silent-toggle bug in `ControlPanel.svelte:97-104` flagged by the brutal-critic UI review.
+
+## Continuity philosophy — knobs should morph, not step
+
+The point of a knob is to allow smooth musical evolution while playing. If turning a knob produces audible "step" jumps between named zones, it's a multi-position selector pretending to be a knob. The Performance view targets two layers of continuity:
+
+### Layer A — continuous Mode (v1, achievable)
+
+Mode is a 0.0–4.0 continuous knob with snap-detents at integer positions. At fractional values the engine interpolates between the two adjacent modes:
+
+| Transition | Engine interpolation |
+|---|---|
+| 0 ↔ 1  (Off → Parallel 3rds) | crossfade harmony output volume in/out |
+| 1 ↔ 2  (Parallel 3rds → 4ths) | morph the diatonic interval: 3rd → tritone-ish blend → 4th |
+| 2 ↔ 3  (Parallel 4ths → Contrary) | per-voice probabilistic motion: P(contrary) = fractional part |
+| 3 ↔ 4  (Contrary → Functional) | chord-tone-awareness weight blend; partially functional, partially contrary |
+
+Implementation: at fractional Mode value M, run `harmonize` for `floor(M)` and `ceil(M)`, then mix output per voice with weight `M - floor(M)`. Live sweeping produces audible morphs, not zone-jumps.
+
+### Layer B — continuous composite knobs (v2, requires engine work)
+
+Today, Tightness / Adventurous / Spread internally jump between zones because the underlying engine takes enums (`voice_leading_style`, `OctaveMode`) or stepped integers (`borrowing_range`). True continuity needs an engine refactor:
+
+| Knob | Today (stepped) | v2 (continuous) |
+|---|---|---|
+| **Tightness** | enum: Free / Smooth / Palestrina / BachChorale | float coefficient applied to voice-leading rule weights (parallel-5th penalty × T, voice-distance penalty × T, etc.) |
+| **Adventurous** | bool `interchange_enabled` + int `borrowing_range` (1-7) | float coefficient: `P(borrow_per_note) = A`, with borrowing depth determined per-note by sampling from a continuous distribution |
+| **Spread** | enum `OctaveMode`: None / Spread / Split / Mirror | float spread coefficient applied per-voice in engine octave-distribution math; the four enum values become preset positions on the same continuum (≈ 0.0, 0.33, 0.66, 1.0) |
+
+v2 work is bigger but eliminates the "stepped feel" entirely and makes every composite knob a true performance dial.
+
+### Why this matters
+
+- Live sweeping a knob produces a continuous timbral morph, not a series of discrete state changes — better for performance gestures (build-ups, drops, transitions).
+- Eliminates the "wall of named zones" problem in composite knobs (the user doesn't think "Free vs Smooth vs Palestrina"; they think "looser vs tighter").
+- Future-proofs the joystick / expression-pedal mapping: continuous external controllers want continuous parameters.
+
+## Emergent unlocks
+
+Recognizable musical idioms surfaced as small badges when the user lands on a particular knob configuration. Not separate modes — emergent labels that teach the user which knob combinations produce which named styles.
+
+| Unlock | Trigger combination |
+|---|---|
+| **Chorale** | Mode=Functional + Tightness>0.9 + Voices=4 + Scale=tonal (Major/Minor/Modal) |
+| **Strict Counterpoint** | Mode=Contrary + Tightness>0.9 + Scale=tonal |
+| **Pop Choir** | Mode=Parallel 3rds + Voices∈{3,4} + Tightness∈[0.4, 0.7] |
+| **Jazz Block** | Mode=Functional + Adventurous>0.5 + Voices=4 + Scale=tonal |
+| **Drone** | Mode=Parallel 4ths + Voices=2 + Tightness<0.3 |
+| **Bagpipe** | Mode=Parallel 4ths + Voices=2 + Spread<0.25 |
+| **Modal Borrowing** | any + Adventurous=1.0 + Scale ∈ Major/Minor/Modal |
+
+UI behavior:
+- While the current configuration matches an unlock, display the badge label in the chord readout area.
+- The unlock label functions as a *de facto* preset name — the user learns "Pop Choir = these three knob positions" by experiencing the badge, then can return to that combination deliberately. This replaces explicit save/recall.
+- Gated by a Settings toggle "Show Advanced Idioms" (default off for v1, on for power users).
+
+## Pads (MPK Mini hardware-mapping reference)
+
+Not all need software equivalents in the Performance view, but the hardware mapping target is:
+
+1. Panic / All-notes-off
+2. Hold harmony (sustain past input)
+3. A/B compare (snapshot vs. live)
+4. Voice-position cycle (SATB next)
+5. Octave-mode cycle (stepped through Spread quantization)
+6. Mode jump → Parallel 3rds (quick reset to a safe default)
+7. Mode jump → Functional (quick jump to chord-tone harmony)
+8. Mode jump → Off (instant harmony bypass)
+
+(No scene save/recall in v1 — see "Save/recall — explicitly out of scope" section. Pads 6/7/8 may become user-assignable in a later iteration.)
+
+## Save/recall — explicitly out of scope for v1
+
+Decision: no preset manager, no named scenes, no save/recall UI. PresetManager (#65) stays unmounted. The brutal-critic UI review flagged this as the single biggest live-perf failure; we are accepting that trade-off because:
+
+- Emergent unlock badges *are* the named-preset surface — they teach the user which knob combinations produce which idioms. "Pop Choir" is the preset name; the knob positions are the recipe.
+- Last-knob-state is already persisted across sessions via localStorage. Users get back to their last-used config on relaunch.
+- A formal preset library adds a save / browse / rename / delete UI surface that contradicts the "8 knobs, no menus" frame of the Performance view.
+
+If save/recall comes back, it does so in a later milestone with a redesigned approach — not by re-mounting the existing PresetManager.
+
+## Knob-value tree
+
+How knob values combine, what each combination produces, and where unlocks emerge. Mode is the root because it's the most categorical knob; everything else modulates the chosen mode.
+
+Legend: 🔓 = emergent unlock badge.
+
+```
+Mode = Off (PassThrough)
+└── No harmony. Voices/Tightness/Adventurous/Spread/Detune all inert.
+    Only useful for A/B-comparing dry signal vs. harmony-on.
+
+
+Mode = Parallel 3rds                      (engine: DiatonicThirds)
+│
+├── Voices = 1
+│   └── Effectively PassThrough (no harmony note generated).
+│
+├── Voices = 2 .. 8
+│   │
+│   ├── Tightness = 0.0 .. 0.3            voice-leading off
+│   │   └── Raw stacked 3rds, parallel motion. Pop/folk default.
+│   │
+│   ├── Tightness = 0.3 .. 0.7            voice-leading on, Free style
+│   │   └── Smooth parallel 3rds, common-tone retention.
+│   │       └── Voices ∈ {3,4} → 🔓 Pop Choir
+│   │
+│   └── Tightness = 0.7 .. 1.0            stricter voice-leading
+│       └── Tightly led parallel 3rds; close to 4-part chorale texture
+│           when Voices = 4 (but not Bach — that needs Functional).
+│
+├── Adventurous = 0.0 .. 0.5              diatonic only
+│   └── Pure in-key 3rds.
+│
+├── Adventurous = 0.5 .. 1.0              modal interchange enabled
+│   └── Out-of-key inputs borrow from parallel modes.
+│       └── Adventurous = 1.0 → 🔓 Modal Borrowing
+│
+├── Spread = 0.0 .. 0.25 (None)
+│   └── Voices clustered around input.
+├── Spread = 0.25 .. 0.5 (Spread)
+│   └── Voices fanned out by octave.
+├── Spread = 0.5 .. 0.75 (BassTrebleSplit)
+│   └── Lower voices pushed down, upper voices pushed up.
+└── Spread = 0.75 .. 1.0 (Mirror)
+    └── Each harmony doubled at ±octave (voice count effectively 2×).
+
+
+Mode = Parallel 4ths                      (engine: DiatonicFourths)
+│
+├── Voices = 2
+│   │
+│   ├── Tightness < 0.3 + held bass note  →  🔓 Drone
+│   │   └── Sparse open-4ths drone texture.
+│   │
+│   ├── Spread < 0.25 (close voicing)     →  🔓 Bagpipe
+│   │   └── Tight quartal voicing, drone-like.
+│   │
+│   └── (otherwise: stacked open 4ths, quartal jazz/modal sound)
+│
+├── Voices = 3 .. 4
+│   └── Stacked 4ths (McCoy Tyner / quartal jazz texture).
+│       Tightness behaves as Mode 1.
+│
+├── Voices = 5 .. 8
+│   └── Wide quartal stack. Tends to blur tonality.
+│
+└── Adventurous = 1.0                     →  🔓 Modal Borrowing
+
+
+Mode = Contrary                            (engine: ContraryMotion)
+│
+├── Voices = 1
+│   └── Effectively PassThrough.
+│
+├── Voices = 2 .. 8
+│   │
+│   ├── Tightness = 0.0 .. 0.3
+│   │   └── Loose contrary motion (harmony goes up when input goes down).
+│   │
+│   ├── Tightness = 0.3 .. 0.7
+│   │   └── Smoothed contrary motion with voice-leading rules.
+│   │
+│   └── Tightness > 0.9                    →  🔓 Strict Counterpoint
+│       └── Engine internally promotes to StrictCounterpoint mode,
+│           Species 1, Strictness=Strict. Independent voices, Fux-style
+│           rules applied.
+│
+├── Note: Contrary is stateful — it tracks input history. Repeated
+│         identical input notes produce different harmonies on purpose.
+│
+└── Adventurous = 1.0                     →  🔓 Modal Borrowing
+
+
+Mode = Functional                          (engine: FunctionalHarmony)
+│
+├── Voices = 1
+│   └── Returns just the input (functional needs ≥ 2 voices to chord).
+│
+├── Voices = 2 .. 3
+│   └── Reduced functional harmony — root + 3rd, or root + 3rd + 5th.
+│
+├── Voices = 4
+│   │
+│   ├── Tightness = 0.0 .. 0.5            loose chord-tone harmony
+│   │   └── Standard chord-tone SATB; voice-leading on but permissive.
+│   │
+│   ├── Tightness = 0.5 .. 0.9            smooth voice-led SATB
+│   │   └── Tighter resolution rules; sounds like good pop arranging.
+│   │
+│   ├── Tightness > 0.9 + Scale=tonal      →  🔓 Chorale
+│   │   └── Engine internally uses BachChorale voicing rules.
+│   │       No parallel 5ths/8ves, stepwise inner voices, classic hymn
+│   │       texture. Suppressed on Pentatonic/World/Symmetric scales.
+│   │
+│   ├── Adventurous = 0.0 .. 0.5
+│   │   └── Diatonic chord choices only.
+│   │
+│   └── Adventurous > 0.5 + Scale=tonal    →  🔓 Jazz Block
+│       └── Modal interchange + extensions; produces 7th/9th/13th
+│           voicings and parallel-minor borrows. Needs tonal scale.
+│
+├── Voices = 5 .. 8
+│   └── Extended functional voicing (works but unconventional).
+│
+├── Scale = Pentatonic
+│   └── Reduced functional harmony — fewer chord tones to land on.
+│       Chorale / Jazz Block unlocks suppressed.
+│
+├── Scale = World / Symmetric
+│   └── Functional harmony degrades — no I-IV-V relationships exist.
+│       Engine falls back to chord-tone-stack of nearest in-scale notes.
+│       All Functional unlocks suppressed; consider switching to
+│       Parallel or Contrary modes for these scales.
+│
+└── Spread mostly cosmetic at Voices = 4 — chorale texture is dense by
+    design. Spread > 0.75 (Mirror) produces choir-with-octave-doubling.
+```
+
+### Reverse index — unlock requirements
+
+| 🔓 Unlock | Mode | Voices | Tightness | Adventurous | Spread | Scale |
+|---|---|---|---|---|---|---|
+| Pop Choir | Parallel 3rds | 3-4 | 0.3–0.7 | any | any | any |
+| Drone | Parallel 4ths | 2 | < 0.3 | any | any | any |
+| Bagpipe | Parallel 4ths | 2 | any | any | < 0.25 | any |
+| Strict Counterpoint | Contrary | 2+ | > 0.9 | any | any | tonal |
+| Chorale | Functional | 4 | > 0.9 | any | any | tonal |
+| Jazz Block | Functional | 4 | any | > 0.5 | any | tonal |
+| Modal Borrowing | any (except Off) | any | any | = 1.0 | any | Major / Minor / Modal |
+
+"tonal" = Major / Minor / Modal categories. Pentatonic / World / Symmetric suppress these unlocks.
+
+### Knobs that don't gate unlocks
+
+- **Key** — transposes everything; doesn't change behavior or trigger unlocks. (Auto-key toggle also doesn't affect unlocks; it just changes how `key` is set.)
+- **You play** — re-slots the user's note in the SATB arrangement; affects placement but not which unlock fires.
+
+### Notes on edge interactions
+
+- **Voices = 1** collapses Parallel/Contrary/Functional to PassThrough behavior in practice. Disable Tightness/Adventurous knobs in the UI when Voices=1 (or grey them out) to prevent confusion.
+- **Voices ≥ 5** outside Functional mode produces walls of stacked intervals. Acceptable but verges on noise; consider a "dense" warning hint.
+- **Adventurous = 1.0 in any non-Off mode** triggers Modal Borrowing — this is the only unlock that's mode-agnostic.
+- Multiple unlocks can match simultaneously (e.g. Chorale + Modal Borrowing at Functional + V=4 + T>0.9 + A=1.0). UI should show the most-specific badge first; Modal Borrowing is the catch-all.
+
+## First-time user experience (FTUX)
+
+Most of the brutal-critic UI review's findings are FTUX failures: silent default mode, no save/recall, invisible internal synth, jargon-only labels, no demo path. This section lays out the FTUX target.
+
+### Principles
+
+1. **Immediate value, no setup ritual.** App opens, user plays, harmony comes out. No mandatory wizard, no "configure your inputs" gate.
+2. **Progressive disclosure via interaction, not via hidden controls.** All 8 knobs visible from the start; tooltips and hints appear as the user touches each knob for the first time. Hidden-by-default controls always backfire.
+3. **Pre-routed audio.** Internal Synth is the default output and is wired to play harmonies immediately on first note. External MIDI is opt-in.
+4. **Education without lecture.** No modal walkthroughs, no multi-step "Next" flows. Tips appear contextually as the user explores.
+
+### Cold-start defaults
+
+The target: cold-start user presses any laptop key and hears consonant harmony in under 2 seconds.
+
+| Setting | Default | Reason |
+|---|---|---|
+| View mode | Performance (8 knobs) | Avoid confronting the user with the Advanced wall on first launch |
+| Mode | Parallel 3rds | Simplest audible harmony — not PassThrough (which is silent) |
+| Voices | 2 | One harmony voice + user's input — minimum to demonstrate the product |
+| Tightness | 0.5 (mid) | Smooth voice-leading, not strict |
+| Adventurous | 0.0 | Diatonic only — no out-of-key surprises for first-time users |
+| Key | C, Auto-key = ON | Auto-detect from input; falls back to C if no input yet |
+| Scale | **Pentatonic** | "No wrong notes" — safest first-touch scale (see Scale section) |
+| You play | Soprano (slot 0) | Default for most users |
+| Spread | 0.0 (None) | Voices clustered; tightest, simplest texture |
+| Input | Computer Keyboard | Universally available; no MIDI hardware required |
+| Output | Internal Synth | Pre-routed; user doesn't need external MIDI to hear anything |
+
+### In-context guidance (action-triggered, not timed)
+
+Time-based tooltip parades annoy users. Tie hints to user actions instead:
+
+| Trigger | Hint |
+|---|---|
+| First Note-On after launch | Toast: *"That's a Pentatonic harmony in 3rds. Try the knobs."* |
+| First hover on Mode | *"Sweep this to morph between harmony styles: thirds → fourths → contrary motion → block chords."* |
+| First hover on Voices | *"More voices = thicker harmony. Try 4 for SATB choir."* |
+| First hover on Tightness | *"How smoothly the voices move. Higher = more refined voice-leading."* |
+| First hover on Adventurous | *"How often the harmony borrows out-of-key chords. Higher = more colorful, less predictable."* |
+| First hover on Spread | *"How widely the voices spread around your note."* |
+| First emergent unlock fires | Badge appears with one-line description (e.g. *"Pop Choir — Parallel 3rds, 3-4 voices, smooth voice-leading"*). Doubles as the de facto preset name; user learns the recipe. |
+| After 5+ knobs explored | Toast: *"Curious about deeper controls? Try Advanced view."* |
+
+Each "first hover" hint is shown once per knob per device, persisted via localStorage flag.
+
+### Empty state (no input yet)
+
+If 10 seconds elapse after launch with no Note-On:
+
+- Display copy: *"Press any key on your computer, plug in a MIDI device, or click ▶ to hear a demo."*
+- ▶ button triggers the Demo (below).
+
+### Demo mode
+
+Always accessible from empty state and from a small "Demo" button in the StatusBar:
+
+- Plays a 10-second held C-Pentatonic chord through the engine.
+- Knobs visibly animate during playback: Mode sweeps left-to-right, Voices builds 1→2→3→4, Tightness rises, Adventurous nudges up partway through.
+- User sees the parameter → sound mapping without having to play.
+- "Skip" / "Stop" interrupts. "Apply this config" copies the demo's final knob state to the user's session.
+- Useful for non-musicians who don't yet know what any of the controls *do*.
+
+### What FTUX is not
+
+- A modal wizard the user must dismiss before playing.
+- A multi-step "configure your audio" gate.
+- A click-Next tutorial.
+- A skill-level questionnaire.
+- Hidden controls revealed by milestones / achievements.
+
+### Connection to other systems
+
+- Cold-start defaults assume the **Quick wins** patches have shipped: default mode is no longer PassThrough, internal synth is auto-routed, Computer Keyboard input is the default selection.
+- In-context hints persist their "shown once" flags in the same localStorage that holds settings.
+- **Emergent unlocks are the long-term FTUX teacher** — each unlock that fires teaches the user a parameter-combo → named-idiom mapping. The badge system carries the educational load after the cold-start hints are exhausted.
+
+## Quick wins (independent of Performance view)
+
+These should ship before or alongside the redesign — they fix bugs the brutal-critic UI review flagged that aren't tied to the new view:
+
+- Change default `mode: 'PassThrough'` → `'DiatonicThirds'` so first launch produces audible harmony
+- Fix Auto-key + Key-dropdown silent toggle interaction
+- Expand voiceCount picker from 1-4 to 1-8 (engine already supports it)
+- Rename `Rng` → "Borrow depth" in the Advanced view
+- Tempo-density guard for Counterpoint Species 3/4 (or demote them out of the top-level mode picker)
+
+(PresetManager re-mount removed — preset/scene management is explicitly out of scope; see the "Save/recall" decision above.)
+
+## Open questions
+
+- Should the unlock badge persist while in zone, or flash once on entry?
+- True continuous Spread vs. quantized-to-enum: v1 design call
+- Touch target sizing — current UI uses sub-12px labels and 40px buttons; Performance view needs much larger hit targets for one-handed live use
+- View-mode switcher placement — StatusBar pill / Settings toggle / dedicated chrome
+- Scale category default sub-modes — should "last-used" override the per-category default once user has explored, or always reset to default on category change?
+- Detune was dropped from the 8 knobs — does it deserve a slot in the Setup pane / Settings, or is it OK to retire entirely from the Performance-view audience?
+
+## Out of scope for v1
+
+- Reactive / auto-evolving harmony (fast playing → simpler, slow → richer)
+- Per-scene tempo / beat-phase
+- Programmable mode trajectories (verse=parallel, chorus=functional auto-transitions)
+- Audio preview on Mode detent change
+- Joystick-based morphing of Adventurous
+
+## Implementation notes
+
+- The existing `engine.svelte.ts` setters are the dispatch surface. Composite knobs (Tightness, Adventurous, Spread) read 0..1 and fire 1-3 `adapter.set*` calls per change.
+- View-switching state lives in the same `ui.svelte.ts` store that owns the panel-pip toggles. The two systems are orthogonal: panel pips control which existing-UI panels are visible inside Advanced view; the Performance view is a separate top-level layout.
+- When the user switches Advanced → Performance, composite knobs display their last-known position. No attempt to invert-map advanced state to composite-knob positions.

--- a/crates/contrapunk-harmony/src/engine.rs
+++ b/crates/contrapunk-harmony/src/engine.rs
@@ -229,6 +229,11 @@ pub struct HarmonyEngine {
     key: Key,
     mode: HarmonyMode,
     octave_mode: OctaveMode,
+    /// Continuous coefficient applied to Spread and BassTrebleSplit
+    /// displacement amounts. Range [0.0, 1.0]; default 1.0 preserves
+    /// the legacy full-octave behavior. The simple-view Spread knob
+    /// uses this for smooth audible morphs as the knob sweeps.
+    octave_intensity: f32,
     scale_mode: ScaleMode,
     scale: Scale,
     interchange_enabled: bool,
@@ -278,6 +283,15 @@ pub struct HarmonyEngine {
     /// they would otherwise stay stuck. Drained by the router each
     /// `harmonize_note_on` cycle via `take_pending_releases`.
     pending_releases: Vec<Note>,
+    /// Input MIDI notes that were held when a parameter change cleared
+    /// `active_notes`. The router drains this via
+    /// `take_reharm_inputs()` and re-runs `harmonize_note_on` for each
+    /// to produce fresh harmonies under the new parameters, then diffs
+    /// against the previously-sounding harmony set so only notes that
+    /// actually drop out get `NoteOff` and only newly-needed notes get
+    /// `NoteOn`. The user's held input never gets interrupted —
+    /// transitions between knob positions are seamless.
+    pending_reharm_inputs: Vec<u8>,
 }
 
 impl HarmonyEngine {
@@ -297,6 +311,7 @@ impl HarmonyEngine {
             key,
             mode,
             octave_mode: OctaveMode::None,
+            octave_intensity: 1.0,
             scale_mode: ScaleMode::Ionian,
             scale,
             interchange_enabled: false,
@@ -323,6 +338,7 @@ impl HarmonyEngine {
             counterpoint_strictness: CounterpointStrictness::default(),
             saved_scale_mode: None,
             pending_releases: Vec::new(),
+            pending_reharm_inputs: Vec::new(),
             harmonic_context: None,
         }
     }
@@ -367,8 +383,7 @@ impl HarmonyEngine {
     pub fn set_octave_mode(&mut self, octave_mode: OctaveMode) {
         self.octave_mode = octave_mode;
         // Clear note tracking since octave transformations change output
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
     }
 
     /// Returns the current voice count.
@@ -393,8 +408,7 @@ impl HarmonyEngine {
             position, self.voice_count
         );
         self.voice_position = position;
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
         self.voice_leading
             .rebuild_for_voices(self.voice_count, position);
     }
@@ -429,8 +443,7 @@ impl HarmonyEngine {
                 s
             })
             .collect();
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
         self.voice_leading
             .rebuild_for_voices(count, self.voice_position);
     }
@@ -454,8 +467,7 @@ impl HarmonyEngine {
         // Reset harmonic context to avoid stale chord state from previous key
         self.harmonic_context = None;
         // Clear note tracking since harmonies would change with new scale
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
         self.voice_leading.reset();
         // Clear cached beat-phase; router will push a fresh value next cycle.
         self.counterpoint_beat_phase = None;
@@ -500,8 +512,7 @@ impl HarmonyEngine {
         // Reset harmonic context to avoid stale chord state from previous mode
         self.harmonic_context = None;
         // Clear note tracking since harmonies would change with new mode
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
         self.voice_leading.reset();
         // Clear cached beat-phase; router pushes a fresh value on next cycle.
         self.counterpoint_beat_phase = None;
@@ -542,8 +553,7 @@ impl HarmonyEngine {
         }
         // Reset harmonic context to avoid stale chord state from previous scale mode
         self.harmonic_context = None;
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
         self.voice_leading.reset();
         // Clear cached beat-phase; router pushes a fresh value on next cycle.
         self.counterpoint_beat_phase = None;
@@ -558,8 +568,7 @@ impl HarmonyEngine {
     pub fn set_interchange_enabled(&mut self, enabled: bool) {
         self.interchange_enabled = enabled;
         self.scale.set_interchange_enabled(enabled);
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
     }
 
     /// Returns the current borrowing range (1-5).
@@ -571,8 +580,7 @@ impl HarmonyEngine {
     pub fn set_borrowing_range(&mut self, range: u8) {
         self.borrowing_range = range.clamp(1, 5);
         self.scale.set_borrowing_range(self.borrowing_range);
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
     }
 
     /// Returns the last mode borrowed from during modal interchange.
@@ -596,15 +604,29 @@ impl HarmonyEngine {
         if !enabled {
             self.voice_leading.reset();
         }
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
     }
 
     /// Sets the voice leading style, resetting VL state.
     pub fn set_voice_leading_style(&mut self, style: VoiceLeadingStyle) {
         self.voice_leading.set_style(style);
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
+    }
+
+    /// Continuous octave-spread coefficient applied to Spread and
+    /// BassTrebleSplit modes. Range [0.0, 1.0]; 0.0 = no displacement,
+    /// 1.0 = full-octave (legacy) displacement.
+    pub fn octave_intensity(&self) -> f32 {
+        self.octave_intensity
+    }
+
+    pub fn set_octave_intensity(&mut self, amount: f32) {
+        let clamped = amount.clamp(0.0, 1.0);
+        if (clamped - self.octave_intensity).abs() < f32::EPSILON {
+            return;
+        }
+        self.octave_intensity = clamped;
+        self.clear_active_for_reharm();
     }
 
     pub fn set_beat_phase(&mut self, phase: BeatPhase) {
@@ -637,8 +659,7 @@ impl HarmonyEngine {
         for state in &mut self.counterpoint_states {
             state.set_species(species);
         }
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
     }
 
     /// Returns the active counterpoint strictness (Relaxed vs Strict).
@@ -652,8 +673,7 @@ impl HarmonyEngine {
         for state in &mut self.counterpoint_states {
             state.set_strictness(strictness);
         }
-        self.active_notes.clear();
-        self.active_port_maps.clear();
+        self.clear_active_for_reharm();
     }
 
     /// Harmonizes a single note based on the current mode.
@@ -859,12 +879,17 @@ impl HarmonyEngine {
             }
         };
 
+        let intensity = self.octave_intensity;
         match self.octave_mode {
             OctaveMode::None => {}
             OctaveMode::Spread => {
                 for (i, note) in notes.iter_mut().enumerate().skip(1) {
                     let midi = u8::from(*note);
-                    let shifted = midi.saturating_add((i as u8) * 12).min(127);
+                    // Continuous: per-voice shift = i × intensity × 12.
+                    // intensity = 0 → no displacement. intensity = 1 →
+                    // full-octave per voice (legacy behavior).
+                    let shift = ((i as f32) * intensity * 12.0).round().max(0.0) as u8;
+                    let shifted = midi.saturating_add(shift).min(127);
                     if anchor_ok(i, shifted) {
                         if let Ok(new_note) = Note::try_from(shifted) {
                             *note = new_note;
@@ -874,12 +899,13 @@ impl HarmonyEngine {
                 }
             }
             OctaveMode::BassTrebleSplit => {
+                let shift = (intensity * 12.0).round().max(0.0) as u8;
                 for (i, note) in notes.iter_mut().enumerate().skip(1) {
                     let midi = u8::from(*note);
                     let shifted = if midi < user_midi {
-                        midi.saturating_sub(12)
+                        midi.saturating_sub(shift)
                     } else {
-                        midi.saturating_add(12).min(127)
+                        midi.saturating_add(shift).min(127)
                     };
                     if anchor_ok(i, shifted) {
                         if let Ok(new_note) = Note::try_from(shifted) {
@@ -1251,6 +1277,27 @@ impl HarmonyEngine {
     /// take over. Returns an empty Vec when no key change happened.
     pub fn take_pending_releases(&mut self) -> Vec<Note> {
         std::mem::take(&mut self.pending_releases)
+    }
+
+    /// Drain the list of input MIDI notes that were held when a
+    /// parameter change wiped `active_notes`. The router re-runs
+    /// `harmonize_note_on` for each so the new parameters take effect
+    /// without dropping the user's held input.
+    pub fn take_reharm_inputs(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.pending_reharm_inputs)
+    }
+
+    /// Wipe per-note tracking after a parameter change, but record the
+    /// held input MIDI numbers in `pending_reharm_inputs` so the router
+    /// can replay them under the new parameters. Replaces the previous
+    /// `self.active_notes.clear(); self.active_port_maps.clear();`
+    /// idiom in every parameter setter — the user's held inputs no
+    /// longer drop on knob changes.
+    fn clear_active_for_reharm(&mut self) {
+        self.pending_reharm_inputs
+            .extend(self.active_notes.keys().copied());
+        self.active_notes.clear();
+        self.active_port_maps.clear();
     }
 
     pub fn harmonize_note_off(&mut self, note: Note) -> Vec<Note> {

--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -370,25 +370,109 @@ fn run_tauri_router(
             break;
         }
 
-        // Panic handling: any engine-config command that could strand
-        // active notes sets panic_pending. Emit MIDI All-Notes-Off (CC
-        // 123) on every channel × every port to release stuck notes,
-        // then clear tracked note state so the UI stops showing them.
+        // Reharmonize on parameter change. Any engine-config setter that
+        // could change the harmony output sets panic_pending and stashes
+        // the previously-held input MIDI numbers in the engine's
+        // `pending_reharm_inputs`. We replay each of those inputs under
+        // the new parameters, compute a diff against the previously-
+        // sounding harmony set, and dispatch only the difference:
+        // NoteOff for harmony notes that drop out, NoteOn for newly-
+        // needed ones. The user's held input note never gets
+        // interrupted — knob sweeps produce a smooth musical morph.
         if panic_pending.swap(false, Ordering::SeqCst) {
-            let num_ports = output_router.connection_count();
-            for p in 0..num_ports {
-                for ch in 0u8..16 {
-                    let _ = output_router.send_to_port(p, &[0xB0 | ch, 123, 0]);
+            // Snapshot what's currently sounding (harmony + borrowed only —
+            // input notes belong to the user, leave them alone).
+            let old_harmonies: HashSet<u8> = {
+                let h = harmony_notes.lock().unwrap_or_else(|e| e.into_inner());
+                let b = borrowed_notes.lock().unwrap_or_else(|e| e.into_inner());
+                h.iter().chain(b.iter()).copied().collect()
+            };
+
+            // Drain held inputs from the engine and replay them under the
+            // new parameters. Each replay populates `active_notes` and
+            // updates `last_port_map` for the per-voice routing below.
+            let mut new_harmonies: HashSet<u8> = HashSet::new();
+            let mut per_input: Vec<(Vec<u8>, Vec<usize>)> = Vec::new();
+            {
+                let mut eng = engine.lock().unwrap_or_else(|e| e.into_inner());
+                let inputs = eng.take_reharm_inputs();
+                for midi in inputs {
+                    if let Ok(input_note) = Note::try_from(midi) {
+                        let result = eng.harmonize_note_on(input_note);
+                        let port_map = eng.last_port_map().to_vec();
+                        // Skip index 0 (the input itself) — only harmonies
+                        // contribute to the diff. Input keeps ringing.
+                        let harm_midis: Vec<u8> =
+                            result.iter().skip(1).map(|n| u8::from(*n)).collect();
+                        for &m in &harm_midis {
+                            new_harmonies.insert(m);
+                        }
+                        // Keep the input + harmonies + ports together so we
+                        // can route attacks correctly. Index 0 of harm_midis
+                        // is unused (input is at result[0]); we store the
+                        // full result for routing.
+                        let full_midis: Vec<u8> = result.iter().map(|n| u8::from(*n)).collect();
+                        per_input.push((full_midis, port_map));
+                    }
                 }
             }
-            if let Ok(mut n) = input_notes.lock() {
-                n.clear();
+
+            let to_release: Vec<u8> = old_harmonies.difference(&new_harmonies).copied().collect();
+            let to_attack: HashSet<u8> =
+                new_harmonies.difference(&old_harmonies).copied().collect();
+
+            // Send NoteOff for released notes — synth + every external
+            // port (overspray on external is harmless; we don't track
+            // per-note routing for releases).
+            let num_ports = output_router.connection_count();
+            for n in &to_release {
+                let _ = synth_tx.send(SynthEvent::NoteOff { note: *n });
+                let msg = [0x80, *n, 0]; // NoteOff channel 0
+                for p in 0..num_ports {
+                    let _ = output_router.send_to_port(p, &msg);
+                }
             }
-            if let Ok(mut n) = harmony_notes.lock() {
-                n.clear();
+
+            // Send NoteOn for newly-attacked notes, routed per voice via
+            // each replay's port map and the live voice_outputs table.
+            let voice_targets: Vec<VoiceOutputTarget> = voice_outputs
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone();
+            for (midis, port_map) in &per_input {
+                // Skip index 0 — that's the user's input note, already
+                // sounding from when they pressed the key.
+                for (i, &n) in midis.iter().enumerate().skip(1) {
+                    if !to_attack.contains(&n) {
+                        continue; // already sounding from before
+                    }
+                    let slot = port_map.get(i).copied().unwrap_or(i);
+                    let target = voice_targets.get(slot).copied().unwrap_or_default();
+                    match target {
+                        VoiceOutputTarget::Synth => {
+                            let _ = synth_tx.send(SynthEvent::NoteOn {
+                                note: n,
+                                velocity: 100,
+                            });
+                        }
+                        VoiceOutputTarget::MidiPort { port } => {
+                            if port < num_ports {
+                                let msg = [0x90, n, 100]; // NoteOn channel 0
+                                let _ = output_router.send_to_port(port, &msg);
+                            }
+                        }
+                        VoiceOutputTarget::Off => {}
+                    }
+                }
             }
-            if let Ok(mut n) = borrowed_notes.lock() {
-                n.clear();
+
+            // Replace UI tracking sets with the new harmony state. Input
+            // notes stay as-is — user's still holding them.
+            if let Ok(mut h) = harmony_notes.lock() {
+                *h = new_harmonies;
+            }
+            if let Ok(mut b) = borrowed_notes.lock() {
+                b.clear();
             }
         }
 

--- a/src-tauri/src/commands/harmony.rs
+++ b/src-tauri/src/commands/harmony.rs
@@ -220,6 +220,18 @@ pub fn set_routing_mode(mode: String, state: State<AppState>) -> Result<(), Stri
     Ok(())
 }
 
+/// Continuous octave-spread coefficient applied to Spread / Split modes.
+/// Range [0.0, 1.0]; 0 = no displacement, 1 = legacy full-octave behavior.
+#[tauri::command]
+pub fn set_octave_intensity(amount: f32, state: State<AppState>) -> Result<(), String> {
+    {
+        let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
+        engine.set_octave_intensity(amount);
+    }
+    raise_panic(&state);
+    Ok(())
+}
+
 /// Set global detune in cents. The router thread reads this atomically each
 /// frame and sends MIDI pitch bend to all output ports when the value changes.
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -64,6 +64,7 @@ fn main() {
             commands::harmony::set_mode,
             commands::harmony::set_scale_mode,
             commands::harmony::set_octave_mode,
+            commands::harmony::set_octave_intensity,
             commands::harmony::set_voice_leading,
             commands::harmony::set_interchange,
             commands::harmony::set_voice_position,

--- a/ui/src/lib/adapter/plugin.ts
+++ b/ui/src/lib/adapter/plugin.ts
@@ -107,6 +107,10 @@ export class PluginAdapter implements ContrapunkAdapter {
 		this.send('setOctaveMode', mode);
 	}
 
+	async setOctaveIntensity(amount: number): Promise<void> {
+		this.send('setOctaveIntensity', amount);
+	}
+
 	async setVoiceLeading(enabled: boolean, _style: string): Promise<void> {
 		this.send('setVoiceLeading', enabled);
 	}

--- a/ui/src/lib/adapter/tauri.ts
+++ b/ui/src/lib/adapter/tauri.ts
@@ -153,6 +153,14 @@ export class TauriAdapter implements ContrapunkAdapter {
 		}
 	}
 
+	async setOctaveIntensity(amount: number): Promise<void> {
+		try {
+			await invoke('set_octave_intensity', { amount });
+		} catch (e) {
+			throw new Error(`Failed to set octave intensity: ${e}`);
+		}
+	}
+
 	async setVoiceLeading(enabled: boolean, style: string): Promise<void> {
 		try {
 			await invoke('set_voice_leading', { enabled, style });

--- a/ui/src/lib/adapter/types.ts
+++ b/ui/src/lib/adapter/types.ts
@@ -184,6 +184,12 @@ export interface ContrapunkAdapter {
 	/** Set the octave mode (e.g. "None", "Spread", "Mirror"). */
 	setOctaveMode(mode: string): Promise<void>;
 
+	/** Continuous octave-spread coefficient applied to Spread / Split modes.
+	 *  Range [0.0, 1.0]; 0 = no displacement, 1 = full-octave (legacy)
+	 *  displacement. Used by the Performance view's Spread knob for
+	 *  smooth audible morphs. */
+	setOctaveIntensity(amount: number): Promise<void>;
+
 	/** Configure voice leading (enabled flag + style). */
 	setVoiceLeading(enabled: boolean, style: string): Promise<void>;
 

--- a/ui/src/lib/adapter/wasm.ts
+++ b/ui/src/lib/adapter/wasm.ts
@@ -158,6 +158,15 @@ export class WasmAdapter implements ContrapunkAdapter {
 		}
 	}
 
+	async setOctaveIntensity(amount: number): Promise<void> {
+		this.ensureInit();
+		try {
+			engine.set_octave_intensity(amount);
+		} catch (e) {
+			throw new Error(`Failed to set octave intensity: ${e}`);
+		}
+	}
+
 	async setVoiceLeading(enabled: boolean, style: string): Promise<void> {
 		this.ensureInit();
 		try {

--- a/ui/src/lib/components/PerformanceView.svelte
+++ b/ui/src/lib/components/PerformanceView.svelte
@@ -1,0 +1,344 @@
+<!--
+	PerformanceView — simplified 8-knob layout for non-experts and live use.
+
+	Spec lives in .planning/PERFORMANCE-VIEW.md. Eight knobs:
+	  Mode  Voices  Tightness  Adventurous
+	  Key   Scale   You play   Spread
+
+	Composite knobs (Tightness / Adventurous / Spread) hold local state and
+	fan out to multiple engine setters on change. They do NOT round-trip
+	from engine state — they just display the user's last-touched position
+	(per .planning/PERFORMANCE-VIEW.md, "Implementation notes").
+-->
+
+<script lang="ts">
+	import { engine, ALL_KEYS, KEY_DISPLAY } from '$lib/stores/engine.svelte';
+	import type {
+		HarmonyModeName,
+		ScaleModeName,
+		VoiceLeadingStyleName,
+		KeyName
+	} from '$lib/stores/engine.svelte';
+	import Knob from './Knob.svelte';
+
+	// === Mode (5 detents) ===
+	const MODE_LABELS = ['Off', 'Parallel 3rds', 'Parallel 4ths', 'Contrary', 'Functional'];
+	const MODE_TO_ENGINE: HarmonyModeName[] = [
+		'PassThrough',
+		'DiatonicThirds',
+		'DiatonicFourths',
+		'ContraryMotion',
+		'FunctionalHarmony'
+	];
+	function engineModeToIndex(m: HarmonyModeName): number {
+		const i = MODE_TO_ENGINE.indexOf(m);
+		return i >= 0 ? i : 0;
+	}
+	let modeIndex = $derived(engineModeToIndex(engine.mode));
+	function onModeChange(v: number) {
+		const i = Math.round(v);
+		void engine.setMode(MODE_TO_ENGINE[i]);
+	}
+
+	// === Scale (8 categories, representative sub-mode each) ===
+	const SCALE_CATEGORIES: { label: string; engine: ScaleModeName }[] = [
+		{ label: 'Pentatonic', engine: 'MajorPentatonic' },
+		{ label: 'Major', engine: 'Ionian' },
+		{ label: 'Natural Minor', engine: 'Aeolian' },
+		{ label: 'Harmonic Min', engine: 'HarmonicMinor' },
+		{ label: 'Melodic Min', engine: 'MelodicMinor' },
+		{ label: 'Modal', engine: 'Dorian' },
+		{ label: 'World', engine: 'Pelog' },
+		{ label: 'Symmetric', engine: 'WholeTone' }
+	];
+	function engineScaleToCategoryIndex(s: ScaleModeName): number {
+		// Map any sub-mode back to its category index for first-paint.
+		const cats: Record<string, number> = {
+			MajorPentatonic: 0, MinorPentatonic: 0, Hirajoshi: 0, InSen: 0, Iwato: 0, Yo: 0, Kumoi: 0,
+			Ionian: 1,
+			Aeolian: 2,
+			HarmonicMinor: 3, LocrianNat6: 3, IonianAug: 3, DorianSharp4: 3,
+			PhrygianDominant: 3, LydianSharp2: 3, SuperLocrianDim: 3,
+			MelodicMinor: 4, DorianFlat2: 4, LydianAug: 4, LydianDominant: 4,
+			MixolydianFlat6: 4, LocrianNat2: 4, SuperLocrian: 4,
+			Dorian: 5, Phrygian: 5, Lydian: 5, Mixolydian: 5, Locrian: 5,
+			Pelog: 6, Persian: 6, NeapolitanMajor: 6, NeapolitanMinor: 6,
+			Enigmatic: 6, HungarianMajor: 6, HungarianMinor: 6, Oriental: 6,
+			WholeTone: 7, DiminishedWholeHalf: 7, DiminishedHalfWhole: 7, AugmentedHex: 7
+		};
+		return cats[s] ?? 1;
+	}
+	let scaleIndex = $derived(engineScaleToCategoryIndex(engine.scaleMode));
+	function onScaleChange(v: number) {
+		const i = Math.round(v);
+		void engine.setScaleMode(SCALE_CATEGORIES[i].engine);
+	}
+
+	// === Key (12 detents) + Auto-key toggle ===
+	function engineKeyToIndex(k: KeyName): number {
+		const i = ALL_KEYS.indexOf(k);
+		return i >= 0 ? i : 0;
+	}
+	let keyIndex = $derived(engineKeyToIndex(engine.key));
+	function onKeyChange(v: number) {
+		const i = Math.round(v);
+		// Touching the Key knob disables Auto-key with a visible state change.
+		// Per the brutal-critic UI review fix (.planning/PERFORMANCE-VIEW.md).
+		if (engine.autoKey) {
+			void engine.setAutoKey(false);
+		}
+		void engine.setKey(ALL_KEYS[i]);
+	}
+
+	// === Voices (1-8) ===
+	function onVoicesChange(v: number) {
+		void engine.setVoiceCount(Math.round(v));
+	}
+
+	// === You play (1..voiceCount) ===
+	function onYouPlayChange(v: number) {
+		void engine.setVoicePosition(Math.round(v) - 1);
+	}
+
+	// === Tightness (0..1, composite) ===
+	let tightness = $state(0.5);
+	function tightnessLabel(t: number): string {
+		if (t < 0.3) return 'Off';
+		if (t < 0.6) return 'Loose';
+		if (t < 0.85) return 'Smooth';
+		return 'Strict';
+	}
+	function applyTightness(t: number) {
+		tightness = t;
+		if (t < 0.3) {
+			void engine.setVoiceLeading(false);
+			return;
+		}
+		const style: VoiceLeadingStyleName =
+			t < 0.6 ? 'Free' : t < 0.85 ? 'Jazz' : 'Palestrina';
+		void engine.setVoiceLeading(true, style);
+	}
+
+	// === Adventurous (0..1, composite) ===
+	let adventurous = $state(0);
+	function adventurousLabel(a: number): string {
+		if (a <= 0.05) return 'In-key';
+		const range = Math.max(1, Math.min(7, Math.round(a * 7)));
+		return `Borrow ${range}`;
+	}
+	function applyAdventurous(a: number) {
+		adventurous = a;
+		if (a <= 0) {
+			void engine.setInterchange(false, 1);
+			return;
+		}
+		const range = Math.max(1, Math.min(7, Math.round(a * 7)));
+		void engine.setInterchange(true, range);
+	}
+
+	// === Spread (continuous via engine octave_intensity coefficient) ===
+	// Engine takes a continuous f32 intensity that scales per-voice
+	// octave displacement. 0 = no spread (matches OctaveMode::None);
+	// 1 = full-octave spread (matches legacy OctaveMode::Spread).
+	// Mirror / BassTrebleSplit aren't exposed in this knob — they
+	// remain available in the Advanced view's full Octave Mode picker.
+	let spread = $state(0);
+	function spreadLabel(s: number): string {
+		if (s <= 0.01) return 'Tight';
+		return `Wide ${Math.round(s * 100)}%`;
+	}
+	function applySpread(s: number) {
+		spread = s;
+		if (s <= 0.01) {
+			void engine.setOctaveMode('None');
+		} else {
+			// Set mode first so apply_octave_mode hits the Spread branch,
+			// then push the intensity coefficient.
+			void engine.setOctaveMode('Spread');
+			void engine.setOctaveIntensity(s);
+		}
+	}
+
+	// Auto-key handling
+	function toggleAutoKey() {
+		void engine.setAutoKey(!engine.autoKey);
+	}
+</script>
+
+<div class="performance-view">
+	<div class="knob-grid">
+		<!-- Row 1 — live performance dials -->
+		<div class="knob-cell">
+			<Knob
+				value={modeIndex}
+				min={0}
+				max={4}
+				step={1}
+				size={72}
+				label="Mode"
+				format={(v) => MODE_LABELS[Math.round(v)] ?? ''}
+				onchange={onModeChange}
+			/>
+		</div>
+		<div class="knob-cell">
+			<Knob
+				value={engine.voiceCount}
+				min={1}
+				max={8}
+				step={1}
+				size={72}
+				label="Voices"
+				format={(v) => Math.round(v).toString()}
+				onchange={onVoicesChange}
+			/>
+		</div>
+		<div class="knob-cell">
+			<Knob
+				value={tightness}
+				min={0}
+				max={1}
+				step={0.01}
+				size={72}
+				label="Tightness"
+				format={tightnessLabel}
+				onchange={applyTightness}
+			/>
+		</div>
+		<div class="knob-cell">
+			<Knob
+				value={adventurous}
+				min={0}
+				max={1}
+				step={0.01}
+				size={72}
+				label="Adventurous"
+				format={adventurousLabel}
+				onchange={applyAdventurous}
+			/>
+		</div>
+
+		<!-- Row 2 — per-song / per-set setup -->
+		<div class="knob-cell">
+			<div class="key-stack">
+				<Knob
+					value={keyIndex}
+					min={0}
+					max={11}
+					step={1}
+					size={72}
+					label="Key"
+					format={(v) => KEY_DISPLAY[ALL_KEYS[Math.round(v)] ?? 'C'] ?? '?'}
+					onchange={onKeyChange}
+				/>
+				<button
+					type="button"
+					class="auto-pip font-ui"
+					class:on={engine.autoKey}
+					onclick={toggleAutoKey}
+					aria-pressed={engine.autoKey}
+					title={engine.autoKey ? 'Auto-key on (engine detects)' : 'Auto-key off (manual)'}
+				>
+					{engine.autoKey ? 'AUTO' : 'MAN'}
+				</button>
+			</div>
+		</div>
+		<div class="knob-cell">
+			<Knob
+				value={scaleIndex}
+				min={0}
+				max={7}
+				step={1}
+				size={72}
+				label="Scale"
+				format={(v) => SCALE_CATEGORIES[Math.round(v)]?.label ?? ''}
+				onchange={onScaleChange}
+			/>
+		</div>
+		<div class="knob-cell">
+			<Knob
+				value={engine.voicePosition + 1}
+				min={1}
+				max={Math.max(1, engine.voiceCount)}
+				step={1}
+				size={72}
+				label="You play"
+				format={(v) => {
+					const i = Math.round(v) - 1;
+					if (engine.voiceCount <= 4) {
+						return ['Soprano', 'Alto', 'Tenor', 'Bass'][i] ?? `V${i + 1}`;
+					}
+					return `V${i + 1}`;
+				}}
+				onchange={onYouPlayChange}
+			/>
+		</div>
+		<div class="knob-cell">
+			<Knob
+				value={spread}
+				min={0}
+				max={1}
+				step={0.01}
+				size={72}
+				label="Spread"
+				format={spreadLabel}
+				onchange={applySpread}
+			/>
+		</div>
+	</div>
+</div>
+
+<style>
+	.performance-view {
+		padding: 0.5rem;
+		container-type: inline-size;
+	}
+
+	/* Always 4 columns × 2 rows — knobs scale via the inline `size`
+	   prop based on container width via @container queries below.
+	   Each cell takes equal width so the layout stays a clean 4-grid
+	   regardless of the parent column's width. */
+	.knob-grid {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 0.5rem;
+		justify-content: stretch;
+		align-items: start;
+	}
+
+	.knob-cell {
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		min-height: 100px;
+		min-width: 0;
+	}
+
+	.key-stack {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.auto-pip {
+		padding: 2px 10px;
+		font-size: var(--font-size-xs, 11px);
+		background: transparent;
+		border: 1px solid var(--color-border, #444);
+		color: var(--color-text-dim, #888);
+		cursor: pointer;
+		letter-spacing: 0.1em;
+		-webkit-font-smoothing: none;
+		text-rendering: optimizeSpeed;
+	}
+	.auto-pip.on {
+		background: var(--color-accent-teal, #1a8a8a);
+		border-color: var(--color-accent-cyan, #4dd);
+		color: #fff;
+		box-shadow: var(--glow-teal, 0 0 6px #1a8a8a);
+	}
+	.auto-pip:hover {
+		border-color: var(--color-accent-cyan, #4dd);
+	}
+
+</style>

--- a/ui/src/lib/components/StatusBar.svelte
+++ b/ui/src/lib/components/StatusBar.svelte
@@ -73,9 +73,36 @@
 	<!-- Spacer -->
 	<div class="spacer"></div>
 
+	<!-- View-mode pill — Performance (8-knob simplified view) vs Advanced
+	     (today's full UI). Persists to localStorage; orthogonal to panel
+	     pips below (panel pips only apply within Advanced view). -->
+	<div class="view-mode-pill" role="group" aria-label="Layout mode">
+		<button
+			type="button"
+			class="vm-btn font-ui"
+			class:on={ui.viewMode === 'performance'}
+			onclick={() => ui.setViewMode('performance')}
+			aria-pressed={ui.viewMode === 'performance'}
+			title="Simplified 8-knob layout"
+		>
+			Simple
+		</button>
+		<button
+			type="button"
+			class="vm-btn font-ui"
+			class:on={ui.viewMode === 'advanced'}
+			onclick={() => ui.setViewMode('advanced')}
+			aria-pressed={ui.viewMode === 'advanced'}
+			title="Full controls"
+		>
+			Advanced
+		</button>
+	</div>
+
 	<!-- Panel pip row — one click toggles a single panel's visibility.
-	     Replaces the old fixed view-mode packs (full / performance /
-	     fretboard / piano) with per-element control. -->
+	     The Simple/Advanced view-mode pill above swaps the Controls
+	     panel's content (8 knobs vs full surface); pips still control
+	     which panels render in either view. -->
 	<div class="panel-pips" role="group" aria-label="Toggle visible panels">
 		{#each PANELS as p}
 			<button
@@ -186,6 +213,40 @@
 
 	.spacer {
 		flex: 1;
+	}
+
+	.view-mode-pill {
+		display: flex;
+		align-items: center;
+		gap: 0;
+		margin-right: 8px;
+	}
+	.vm-btn {
+		padding: 3px 10px;
+		font-size: var(--font-size-xs);
+		background: transparent;
+		border: 1px solid var(--color-border);
+		color: var(--color-text-dim);
+		cursor: pointer;
+		min-width: 0;
+		opacity: 0.7;
+		-webkit-font-smoothing: none;
+		text-rendering: optimizeSpeed;
+	}
+	.vm-btn + .vm-btn {
+		border-left: none;
+	}
+	.vm-btn:hover {
+		border-color: var(--color-accent-cyan);
+		color: var(--color-accent-cyan);
+		opacity: 0.95;
+	}
+	.vm-btn.on {
+		background: var(--color-accent-teal);
+		border-color: var(--color-accent-cyan);
+		color: #ffffff;
+		opacity: 1;
+		box-shadow: var(--glow-teal);
 	}
 
 	.panel-pips {

--- a/ui/src/lib/stores/engine.svelte.ts
+++ b/ui/src/lib/stores/engine.svelte.ts
@@ -646,6 +646,7 @@ class EngineStore {
 	modeNumber = $state(1);
 	scaleMode = $state<ScaleModeName>('Ionian');
 	octaveMode = $state<OctaveModeName>('None');
+	octaveIntensity = $state(1.0);
 
 	// -- Voice leading --
 	voiceLeadingEnabled = $state(false);
@@ -801,6 +802,20 @@ class EngineStore {
 			this.persist();
 		} catch (e) {
 			this.octaveMode = prev;
+			throw e;
+		}
+	}
+
+	/** Continuous octave-spread intensity coefficient. Range [0,1].
+	 *  Used by the Performance view's Spread knob — knob value passes
+	 *  through directly. Combined with setOctaveMode, the engine
+	 *  produces a smooth audible morph as the knob sweeps. */
+	async setOctaveIntensity(amount: number) {
+		const clamped = Math.max(0, Math.min(1, amount));
+		this.octaveIntensity = clamped;
+		try {
+			await adapter.setOctaveIntensity(clamped);
+		} catch (e) {
 			throw e;
 		}
 	}

--- a/ui/src/lib/stores/ui.svelte.ts
+++ b/ui/src/lib/stores/ui.svelte.ts
@@ -13,6 +13,7 @@ const SCALE_KEY = 'contrapunk-ui-scale';
 const FONT_SCALE_KEY = 'contrapunk-font-scale';
 const NOTE_LABELS_KEY = 'contrapunk-show-note-labels';
 const PANELS_KEY = 'contrapunk-panels';
+const VIEW_MODE_KEY = 'contrapunk-view-mode';
 
 const MIN_SCALE = 0.75;
 const MAX_SCALE = 2.0;
@@ -50,6 +51,13 @@ const DEFAULT_PANELS: PanelVisibility = {
 	piano: true
 };
 
+/** Top-level layout choice: the simplified 8-knob Performance view vs.
+ *  the full Advanced surface (today's UI). Orthogonal to `activeTab`
+ *  ('play' vs 'chain') and to the Play-tab `panels` toggles — view mode
+ *  picks WHICH layout, panels pick WHICH bits of the Advanced layout
+ *  render. The Performance view ignores `panels` entirely. */
+export type ViewMode = 'performance' | 'advanced';
+
 // === UI Store (Svelte 5 runes) ===
 
 class UiStore {
@@ -85,6 +93,13 @@ class UiStore {
 	/** Which Play-tab panels render, per `PanelId`. Toggled from the
 	 *  StatusBar pip row; persists to localStorage. */
 	panels = $state<PanelVisibility>({ ...DEFAULT_PANELS });
+
+	/** Top-level layout selection. 'advanced' = today's full UI;
+	 *  'performance' = the simplified 8-knob view. Persists to
+	 *  localStorage so the user lands in their preferred layout on
+	 *  relaunch. Default 'advanced' for now — flip to 'performance'
+	 *  once the new view is feature-complete. */
+	viewMode = $state<ViewMode>('advanced');
 
 	/**
 	 * Toggle animations on/off and apply the reduced-motion class
@@ -230,6 +245,35 @@ class UiStore {
 	private persistPanels() {
 		try {
 			localStorage.setItem(PANELS_KEY, JSON.stringify(this.panels));
+		} catch {
+			/* localStorage unavailable */
+		}
+	}
+
+	/** Switch the top-level layout and persist. */
+	setViewMode(mode: ViewMode) {
+		this.viewMode = mode;
+		try {
+			localStorage.setItem(VIEW_MODE_KEY, mode);
+		} catch {
+			/* localStorage unavailable */
+		}
+	}
+
+	/** Toggle between Performance and Advanced layouts. */
+	toggleViewMode() {
+		this.setViewMode(this.viewMode === 'performance' ? 'advanced' : 'performance');
+	}
+
+	/** Hydrate viewMode from localStorage. Falls back to default if no
+	 *  saved value or value is unrecognized (e.g. forward-compat). */
+	restoreViewMode() {
+		if (typeof window === 'undefined') return;
+		try {
+			const raw = localStorage.getItem(VIEW_MODE_KEY);
+			if (raw === 'performance' || raw === 'advanced') {
+				this.viewMode = raw;
+			}
 		} catch {
 			/* localStorage unavailable */
 		}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import Piano from '$lib/components/Piano.svelte';
 	import MidiDevices from '$lib/components/MidiDevices.svelte';
 	import GuitarInputPanel from '$lib/components/GuitarInputPanel.svelte';
+	import PerformanceView from '$lib/components/PerformanceView.svelte';
 	// PresetManager temporarily unmounted (backend + component file
 	// kept). Tracked in contrapunk#65 — will return with a redesigned UX.
 	import ActiveNotes from '$lib/components/ActiveNotes.svelte';
@@ -40,6 +41,7 @@
 			try {
 				ui.restoreAppearance();
 				ui.restorePanels();
+				ui.restoreViewMode();
 				await adapter.init();
 				await engine.syncFromBackend();
 				await engine.restoreSettings();
@@ -143,7 +145,10 @@
 				<!-- Setup row: MIDI devices + Harmony controls. Each
 				     column is a togglable panel; the row collapses to
 				     a single column when only one is visible, and
-				     disappears entirely when both are off. -->
+				     disappears entirely when both are off. The right
+				     column swaps between PerformanceView (8 knobs) and
+				     ControlPanel (today's full surface) based on
+				     `ui.viewMode`. -->
 				<div
 					class="content-area"
 					class:two-col={ui.panels.midi && ui.panels.controls}
@@ -160,7 +165,11 @@
 					{/if}
 					{#if ui.panels.controls}
 						<div class="column column-center">
-							<ControlPanel />
+							{#if ui.viewMode === 'performance'}
+								<PerformanceView />
+							{:else}
+								<ControlPanel />
+							{/if}
 						</div>
 					{/if}
 				</div>

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -421,6 +421,13 @@ impl Engine {
         Ok(())
     }
 
+    /// Continuous octave-spread coefficient. Range [0.0, 1.0]; 0 = no
+    /// displacement, 1 = full-octave (legacy) per-voice displacement.
+    pub fn set_octave_intensity(&mut self, amount: f32) {
+        self.inner.set_octave_intensity(amount);
+        self.clear_notes();
+    }
+
     /// Configure voice leading (enabled flag + style string).
     pub fn set_voice_leading(&mut self, enabled: bool, style: &str) -> Result<(), JsValue> {
         let vl_style = parse_voice_leading_style(style)?;


### PR DESCRIPTION
## Summary
- New switchable **Performance view** — simplified 8-knob layout (Mode / Voices / Tightness / Adventurous / Key+Auto / Scale / You play / Spread). Toggle via the Simple|Advanced pill in StatusBar; swaps only the Controls column. Default stays Advanced; existing users see no change unless they click Simple.
- **Diff-based reharmonization** — every panic-raising knob change now replays held inputs under the new params and dispatches only the diff (NoteOff for harmony notes that drop out, NoteOn for newly-needed ones). User's held input keeps ringing across knob sweeps. Fixes the stuck-notes-on-internal-synth bug; smoother live transitions overall.
- **Continuous Spread (Layer B proof of concept)** — engine takes a new continuous f32 `octave_intensity` coefficient that scales per-voice octave displacement. Sweeping the knob produces an audible morph instead of stepping between four enum values.
- **Design docs** — `.planning/PERFORMANCE-VIEW.md` (8-knob spec, mode spectrum, composite mappings, scale categories Pentatonic-first, unlocks, FTUX, quick wins) and `.planning/PERFORMANCE-VIEW-USER-TESTING.md` (30-min non-musician observation script).

## Test plan
- [ ] Toggle Simple|Advanced pill in StatusBar — only the right Controls column swaps; MIDI/Notes/Piano/Fretboard panels stay
- [ ] In Simple view, knobs render in a 4-column responsive grid (2 rows of 4)
- [ ] Mode knob: cycles Off → Parallel 3rds → Parallel 4ths → Contrary → Functional with friendly labels
- [ ] Voices knob: 1-8 detents
- [ ] Key knob: 12 detents; AUTO/MAN pip toggles auto-key; grabbing the knob while AUTO is on disables auto with a visible state change
- [ ] Scale knob: 8 categories, Pentatonic first
- [ ] You play: Soprano/Alto/Tenor/Bass labels at voiceCount ≤ 4
- [ ] Spread knob: smooth audible morph as it sweeps from Tight to Wide 100% (not stepped between the old 4 OctaveMode values)
- [ ] Hold a note + change any knob → user's input keeps ringing; only stale harmony notes drop, new ones fade in
- [ ] All 247 harmony lib tests still pass
- [ ] svelte-check: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)