### PR TITLE
feat(tauri): persist custom .cpk style presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The same Rust core powers the native app, browser app, and DAW plug-ins. Arrange
 - **DAW plug-ins:** published releases may include VST3, CLAP, and macOS Audio Unit assets; check the release asset list.
 - **Full setup guide:** [contrapunk.com/docs/start/install](https://contrapunk.com/docs/start/install/).
 
+Desktop custom harmony-style presets persist as versioned `.cpk` files in the app-data directory. They do not yet include synth, plug-in, routing, Slide, or Companion state.
+
 ### Logic Pro
 
 Contrapunk provides two Audio Units under **Contrapunk Audio**:

--- a/crates/contrapunk-preset/src/lib.rs
+++ b/crates/contrapunk-preset/src/lib.rs
@@ -4,9 +4,6 @@ pub mod storage;
 use contrapunk_harmony::{HarmonyMode, Key, OctaveMode, ScaleMode, VoiceLeadingStyle};
 use serde::{Deserialize, Serialize};
 
-// Import for flexible JSON values to avoid circular dependencies
-use serde_json::Value;
-
 /// A complete musical style preset bundling harmony, voice leading,
 /// humanization, and octave settings into a selectable style.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -104,25 +101,4 @@ impl PresetManager {
     pub fn set_custom_presets(&mut self, presets: Vec<StylePreset>) {
         self.custom = presets;
     }
-}
-
-/// Complete plugin state payload requested by the reviewer.
-/// Uses serde_json::Value to avoid dependency cycles with other crates.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ContrapunkPresetPayload {
-    /// Format version for backward compatibility
-    pub version: u32,
-
-    /// Core harmony and style config
-    pub style: StylePreset,
-
-    /// Active voice count
-    pub voice_count: usize,
-
-    /// External crate states stored as JSON
-    pub mixer: Value,
-    pub tuning: Value,
-    pub routing: Value,
-    pub slide_enabled: bool,
-    pub companion: Value,
 }

--- a/crates/contrapunk-preset/src/lib.rs
+++ b/crates/contrapunk-preset/src/lib.rs
@@ -4,6 +4,9 @@ pub mod storage;
 use contrapunk_harmony::{HarmonyMode, Key, OctaveMode, ScaleMode, VoiceLeadingStyle};
 use serde::{Deserialize, Serialize};
 
+// Import for flexible JSON values to avoid circular dependencies
+use serde_json::Value;
+
 /// A complete musical style preset bundling harmony, voice leading,
 /// humanization, and octave settings into a selectable style.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -101,4 +104,25 @@ impl PresetManager {
     pub fn set_custom_presets(&mut self, presets: Vec<StylePreset>) {
         self.custom = presets;
     }
+}
+
+/// Complete plugin state payload requested by the reviewer.
+/// Uses serde_json::Value to avoid dependency cycles with other crates.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ContrapunkPresetPayload {
+    /// Format version for backward compatibility
+    pub version: u32,
+
+    /// Core harmony and style config
+    pub style: StylePreset,
+
+    /// Active voice count
+    pub voice_count: usize,
+
+    /// External crate states stored as JSON
+    pub mixer: Value,
+    pub tuning: Value,
+    pub routing: Value,
+    pub slide_enabled: bool,
+    pub companion: Value,
 }

--- a/crates/contrapunk-preset/src/storage.rs
+++ b/crates/contrapunk-preset/src/storage.rs
@@ -37,24 +37,14 @@ pub fn save_preset_to_file(payload: &ContrapunkPresetPayload, file_path: &Path) 
     Ok(())
 }
 
-
-
-
-
-
-
-
-
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{StylePreset, ContrapunkPresetPayload};
+    use crate::{ContrapunkPresetPayload, StylePreset};
     use contrapunk_harmony::{HarmonyMode, Key, OctaveMode, ScaleMode, VoiceLeadingStyle};
     use serde_json::json;
-    use std::fs;
     use std::env;
+    use std::fs;
 
     fn get_dummy_payload() -> ContrapunkPresetPayload {
         ContrapunkPresetPayload {
@@ -64,11 +54,11 @@ mod tests {
                 persona: "Test".into(),
                 genre: "Test".into(),
                 harmony_mode: HarmonyMode::PassThrough, // Fixed based on config.rs
-                key: Key::C, // Valid Key
+                key: Key::C,                            // Valid Key
                 voice_leading_enabled: false,
                 voice_leading_style: Default::default(), // Auto-fetch the default style
-                octave_mode: OctaveMode::None, // Fixed based on config.rs
-                scale_mode: ScaleMode::Ionian, // Valid ScaleMode
+                octave_mode: OctaveMode::None,           // Fixed based on config.rs
+                scale_mode: ScaleMode::Ionian,           // Valid ScaleMode
                 interchange_enabled: false,
                 borrowing_range: 3,
                 is_builtin: false,
@@ -85,7 +75,7 @@ mod tests {
     #[test]
     fn test_cpk_extension_enforcement() {
         let payload = get_dummy_payload();
-        
+
         // Create a path with a WRONG extension
         let mut temp_path = env::temp_dir();
         temp_path.push("wrong_name.txt");
@@ -104,13 +94,14 @@ mod tests {
     #[test]
     fn test_json_round_trip() {
         let payload = get_dummy_payload();
-        
+
         // Serialize
         let json_str = serde_json::to_string(&payload).expect("Failed to serialize");
-        
+
         // Deserialize back
-        let decoded: ContrapunkPresetPayload = serde_json::from_str(&json_str).expect("Failed to deserialize");
-        
+        let decoded: ContrapunkPresetPayload =
+            serde_json::from_str(&json_str).expect("Failed to deserialize");
+
         // Verify data integrity
         assert_eq!(payload.version, decoded.version);
         assert_eq!(payload.style.name, decoded.style.name);

--- a/crates/contrapunk-preset/src/storage.rs
+++ b/crates/contrapunk-preset/src/storage.rs
@@ -1,13 +1,39 @@
 use super::StylePreset;
 
+//Imports for File system (fs) and path handling
+use std::fs;
+use std::path::Path;
+use std::io;
+
 /// Exports a single preset as pretty-printed JSON.
-pub fn export_preset_json(preset: &StylePreset) -> String {
+pub fn export_preset_json(preset: &StylePreset) -> String 
+{
     serde_json::to_string_pretty(preset).unwrap_or_default()
 }
 
 /// Imports a preset from JSON, marking it as non-builtin.
-pub fn import_preset_json(json: &str) -> Option<StylePreset> {
+pub fn import_preset_json(json: &str) -> Option<StylePreset> 
+{
     let mut preset: StylePreset = serde_json::from_str(json).ok()?;
     preset.is_builtin = false;
     Some(preset)
+}
+
+/// To save preset with new custom extention for CONTRAPUNK .cpk
+/// This function uses original `export_preset_json`for data serialize
+/// And ensures that saved file extension is strictly ".cpk"
+
+pub fn save_preset_to_file(preset: &StylePreset, file_path: &Path) -> io::Result<()> 
+{
+    // Serialize preset using existing function
+
+    let json_data = export_preset_json(preset);
+    
+    // Add .cpk extension wherever user want
+    
+    let final_path = file_path.with_extension("cpk");
+    
+    // Write Serialized data onto the system file
+
+    fs::write(final_path, json_data)
 }

--- a/crates/contrapunk-preset/src/storage.rs
+++ b/crates/contrapunk-preset/src/storage.rs
@@ -1,9 +1,19 @@
 use super::StylePreset;
-use crate::ContrapunkPresetPayload;
 
-use std::fs;
-use std::io::{self, Error, ErrorKind};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Error, ErrorKind, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const PRESET_FILE_VERSION: u32 = 1;
+static TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Serialize, Deserialize)]
+struct PresetFile {
+    version: u32,
+    style: StylePreset,
+}
 
 /// Exports a single preset as pretty-printed JSON.
 pub fn export_preset_json(preset: &StylePreset) -> String {
@@ -17,94 +27,150 @@ pub fn import_preset_json(json: &str) -> Option<StylePreset> {
     Some(preset)
 }
 
-/// Saves the full preset payload safely.
-/// Uses a temp file to prevent data loss on write failure.
-pub fn save_preset_to_file(payload: &ContrapunkPresetPayload, file_path: &Path) -> io::Result<()> {
-    // Force .cpk extension
+/// Saves a versioned style preset to a new `.cpk` file without replacing an
+/// existing preset. The completed temporary file is linked into place only
+/// after its contents have been flushed to disk.
+pub fn save_preset_to_file(preset: &StylePreset, file_path: &Path) -> io::Result<()> {
     let final_path = file_path.with_extension("cpk");
+    if final_path.exists() {
+        return Err(Error::new(
+            ErrorKind::AlreadyExists,
+            format!("preset already exists: {}", final_path.display()),
+        ));
+    }
 
-    // Serialize and propagate errors
-    let json_data =
-        serde_json::to_string_pretty(payload).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+    let data = serde_json::to_vec_pretty(&PresetFile {
+        version: PRESET_FILE_VERSION,
+        style: preset.clone(),
+    })
+    .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+    let temp_path = final_path.with_extension(format!(
+        "cpk.{}.{}.tmp",
+        std::process::id(),
+        TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed)
+    ));
 
-    // Write to a temporary file first
-    let temp_path = final_path.with_extension("cpk.tmp");
-    fs::write(&temp_path, json_data)?;
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+        file.write_all(&data)?;
+        file.sync_all()?;
+        drop(file);
 
-    // Atomic rename to replace the original file
-    fs::rename(temp_path, final_path)?;
+        // hard_link is an atomic no-clobber install on the supported desktop
+        // filesystems; unlike rename, it cannot replace an existing Windows file.
+        fs::hard_link(&temp_path, &final_path)
+    })();
+    let _ = fs::remove_file(temp_path);
+    result
+}
 
-    Ok(())
+/// Loads one versioned `.cpk` style preset.
+pub fn load_preset_from_file(file_path: &Path) -> io::Result<StylePreset> {
+    let data = fs::read(file_path)?;
+    let stored: PresetFile =
+        serde_json::from_slice(&data).map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+    if stored.version != PRESET_FILE_VERSION {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("unsupported preset version: {}", stored.version),
+        ));
+    }
+
+    let mut preset = stored.style;
+    preset.is_builtin = false;
+    Ok(preset)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ContrapunkPresetPayload, StylePreset};
     use contrapunk_harmony::{HarmonyMode, Key, OctaveMode, ScaleMode, VoiceLeadingStyle};
-    use serde_json::json;
-    use std::env;
-    use std::fs;
+    use std::path::{Path, PathBuf};
 
-    fn get_dummy_payload() -> ContrapunkPresetPayload {
-        ContrapunkPresetPayload {
-            version: 1,
-            style: StylePreset {
-                name: "Test Preset".into(),
-                persona: "Test".into(),
-                genre: "Test".into(),
-                harmony_mode: HarmonyMode::PassThrough, // Fixed based on config.rs
-                key: Key::C,                            // Valid Key
-                voice_leading_enabled: false,
-                voice_leading_style: Default::default(), // Auto-fetch the default style
-                octave_mode: OctaveMode::None,           // Fixed based on config.rs
-                scale_mode: ScaleMode::Ionian,           // Valid ScaleMode
-                interchange_enabled: false,
-                borrowing_range: 3,
-                is_builtin: false,
-            },
-            voice_count: 4,
-            mixer: json!({}),
-            tuning: json!({}),
-            routing: json!({}),
-            slide_enabled: false,
-            companion: json!({}),
+    static TEST_DIR_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "contrapunk-preset-{label}-{}-{}",
+                std::process::id(),
+                TEST_DIR_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn preset(name: &str) -> StylePreset {
+        StylePreset {
+            name: name.into(),
+            persona: "Test".into(),
+            genre: "Test".into(),
+            harmony_mode: HarmonyMode::PassThrough,
+            key: Key::C,
+            voice_leading_enabled: false,
+            voice_leading_style: VoiceLeadingStyle::default(),
+            octave_mode: OctaveMode::None,
+            scale_mode: ScaleMode::Ionian,
+            interchange_enabled: false,
+            borrowing_range: 3,
+            is_builtin: false,
         }
     }
 
     #[test]
-    fn test_cpk_extension_enforcement() {
-        let payload = get_dummy_payload();
+    fn save_enforces_extension_and_round_trips() {
+        let dir = TestDir::new("round-trip");
+        let requested_path = dir.path().join("custom.txt");
+        let expected_path = requested_path.with_extension("cpk");
+        let original = preset("Round Trip");
 
-        // Create a path with a WRONG extension
-        let mut temp_path = env::temp_dir();
-        temp_path.push("wrong_name.txt");
+        save_preset_to_file(&original, &requested_path).unwrap();
 
-        // Save it using our function
-        save_preset_to_file(&payload, &temp_path).expect("Failed to save preset");
-
-        // Verify it forced the .cpk extension
-        let expected_path = temp_path.with_extension("cpk");
-        assert!(expected_path.exists(), "The .cpk file was not created!");
-
-        // Cleanup
-        let _ = fs::remove_file(expected_path);
+        assert!(expected_path.exists());
+        assert!(!requested_path.exists());
+        let loaded = load_preset_from_file(&expected_path).unwrap();
+        assert_eq!(export_preset_json(&original), export_preset_json(&loaded));
     }
 
     #[test]
-    fn test_json_round_trip() {
-        let payload = get_dummy_payload();
+    fn save_preserves_an_existing_preset() {
+        let dir = TestDir::new("no-clobber");
+        let path = dir.path().join("custom.cpk");
+        save_preset_to_file(&preset("Original"), &path).unwrap();
 
-        // Serialize
-        let json_str = serde_json::to_string(&payload).expect("Failed to serialize");
+        let error = save_preset_to_file(&preset("Replacement"), &path).unwrap_err();
 
-        // Deserialize back
-        let decoded: ContrapunkPresetPayload =
-            serde_json::from_str(&json_str).expect("Failed to deserialize");
+        assert_eq!(error.kind(), ErrorKind::AlreadyExists);
+        assert_eq!(load_preset_from_file(&path).unwrap().name, "Original");
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
 
-        // Verify data integrity
-        assert_eq!(payload.version, decoded.version);
-        assert_eq!(payload.style.name, decoded.style.name);
-        assert_eq!(payload.voice_count, decoded.voice_count);
+    #[test]
+    fn load_rejects_unknown_versions() {
+        let dir = TestDir::new("version");
+        let path = dir.path().join("future.cpk");
+        let data = serde_json::json!({ "version": 2, "style": preset("Future") });
+        fs::write(&path, serde_json::to_vec(&data).unwrap()).unwrap();
+
+        let error = load_preset_from_file(&path).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("unsupported preset version"));
     }
 }

--- a/crates/contrapunk-preset/src/storage.rs
+++ b/crates/contrapunk-preset/src/storage.rs
@@ -1,39 +1,119 @@
 use super::StylePreset;
+use crate::ContrapunkPresetPayload;
 
-//Imports for File system (fs) and path handling
 use std::fs;
+use std::io::{self, Error, ErrorKind};
 use std::path::Path;
-use std::io;
 
 /// Exports a single preset as pretty-printed JSON.
-pub fn export_preset_json(preset: &StylePreset) -> String 
-{
+pub fn export_preset_json(preset: &StylePreset) -> String {
     serde_json::to_string_pretty(preset).unwrap_or_default()
 }
 
 /// Imports a preset from JSON, marking it as non-builtin.
-pub fn import_preset_json(json: &str) -> Option<StylePreset> 
-{
+pub fn import_preset_json(json: &str) -> Option<StylePreset> {
     let mut preset: StylePreset = serde_json::from_str(json).ok()?;
     preset.is_builtin = false;
     Some(preset)
 }
 
-/// To save preset with new custom extention for CONTRAPUNK .cpk
-/// This function uses original `export_preset_json`for data serialize
-/// And ensures that saved file extension is strictly ".cpk"
-
-pub fn save_preset_to_file(preset: &StylePreset, file_path: &Path) -> io::Result<()> 
-{
-    // Serialize preset using existing function
-
-    let json_data = export_preset_json(preset);
-    
-    // Add .cpk extension wherever user want
-    
+/// Saves the full preset payload safely.
+/// Uses a temp file to prevent data loss on write failure.
+pub fn save_preset_to_file(payload: &ContrapunkPresetPayload, file_path: &Path) -> io::Result<()> {
+    // Force .cpk extension
     let final_path = file_path.with_extension("cpk");
-    
-    // Write Serialized data onto the system file
 
-    fs::write(final_path, json_data)
+    // Serialize and propagate errors
+    let json_data =
+        serde_json::to_string_pretty(payload).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+
+    // Write to a temporary file first
+    let temp_path = final_path.with_extension("cpk.tmp");
+    fs::write(&temp_path, json_data)?;
+
+    // Atomic rename to replace the original file
+    fs::rename(temp_path, final_path)?;
+
+    Ok(())
+}
+
+
+
+
+
+
+
+
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{StylePreset, ContrapunkPresetPayload};
+    use contrapunk_harmony::{HarmonyMode, Key, OctaveMode, ScaleMode, VoiceLeadingStyle};
+    use serde_json::json;
+    use std::fs;
+    use std::env;
+
+    fn get_dummy_payload() -> ContrapunkPresetPayload {
+        ContrapunkPresetPayload {
+            version: 1,
+            style: StylePreset {
+                name: "Test Preset".into(),
+                persona: "Test".into(),
+                genre: "Test".into(),
+                harmony_mode: HarmonyMode::PassThrough, // Fixed based on config.rs
+                key: Key::C, // Valid Key
+                voice_leading_enabled: false,
+                voice_leading_style: Default::default(), // Auto-fetch the default style
+                octave_mode: OctaveMode::None, // Fixed based on config.rs
+                scale_mode: ScaleMode::Ionian, // Valid ScaleMode
+                interchange_enabled: false,
+                borrowing_range: 3,
+                is_builtin: false,
+            },
+            voice_count: 4,
+            mixer: json!({}),
+            tuning: json!({}),
+            routing: json!({}),
+            slide_enabled: false,
+            companion: json!({}),
+        }
+    }
+
+    #[test]
+    fn test_cpk_extension_enforcement() {
+        let payload = get_dummy_payload();
+        
+        // Create a path with a WRONG extension
+        let mut temp_path = env::temp_dir();
+        temp_path.push("wrong_name.txt");
+
+        // Save it using our function
+        save_preset_to_file(&payload, &temp_path).expect("Failed to save preset");
+
+        // Verify it forced the .cpk extension
+        let expected_path = temp_path.with_extension("cpk");
+        assert!(expected_path.exists(), "The .cpk file was not created!");
+
+        // Cleanup
+        let _ = fs::remove_file(expected_path);
+    }
+
+    #[test]
+    fn test_json_round_trip() {
+        let payload = get_dummy_payload();
+        
+        // Serialize
+        let json_str = serde_json::to_string(&payload).expect("Failed to serialize");
+        
+        // Deserialize back
+        let decoded: ContrapunkPresetPayload = serde_json::from_str(&json_str).expect("Failed to deserialize");
+        
+        // Verify data integrity
+        assert_eq!(payload.version, decoded.version);
+        assert_eq!(payload.style.name, decoded.style.name);
+        assert_eq!(payload.voice_count, decoded.voice_count);
+    }
 }

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -1,8 +1,96 @@
-use contrapunk::preset::storage::save_preset_to_file;
-use contrapunk::preset::ContrapunkPresetPayload;
-use serde_json::json;
+//! Tauri commands for preset management.
+//!
+//! List, load, save, and delete presets.
+
 use std::env;
 use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+
+use serde::Serialize;
+use serde_json::json;
+use tauri::State;
+
+use contrapunk::preset::storage::save_preset_to_file;
+use contrapunk::preset::ContrapunkPresetPayload;
+use contrapunk::preset::StylePreset;
+
+use crate::state::AppState;
+
+/// Serializable preset info for the frontend.
+#[derive(Serialize)]
+pub struct PresetInfo {
+    pub index: usize,
+    pub name: String,
+    pub persona: String,
+    pub genre: String,
+    pub is_builtin: bool,
+}
+
+/// Lists all available presets (builtins + custom).
+#[tauri::command]
+pub fn list_presets(state: State<AppState>) -> Result<Vec<PresetInfo>, String> {
+    let manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
+    let presets = manager.all_presets();
+    Ok(presets
+        .iter()
+        .enumerate()
+        .map(|(i, p)| PresetInfo {
+            index: i,
+            name: p.name.clone(),
+            persona: p.persona.clone(),
+            genre: p.genre.clone(),
+            is_builtin: p.is_builtin,
+        })
+        .collect())
+}
+
+/// Loads a preset by name and applies it to the engine.
+#[tauri::command]
+pub fn load_preset(name: String, state: State<AppState>) -> Result<(), String> {
+    apply_preset_inner(&state, &name)
+}
+
+/// Inner implementation of `load_preset` that operates on a plain
+/// `&AppState` reference. Extracted from the Tauri command wrapper so
+/// the regression test can exercise the full reharm path without
+/// standing up a `tauri::State`.
+pub(crate) fn apply_preset_inner(state: &AppState, name: &str) -> Result<(), String> {
+    let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
+
+    // Find preset by name — two-phase to avoid borrow conflict
+    let (idx, preset) = {
+        let all = manager.all_presets();
+        let found = all.iter().enumerate().find(|(_, p)| p.name == name);
+        match found {
+            Some((idx, p)) => (idx, (*p).clone()),
+            None => return Err(format!("Preset not found: {}", name)),
+        }
+    };
+    manager.set_active(idx);
+
+    // Apply preset to engine
+    {
+        let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
+        engine.set_key(preset.key);
+        engine.set_mode(preset.harmony_mode);
+        engine.set_octave_mode(preset.octave_mode);
+        engine.set_voice_leading_enabled(preset.voice_leading_enabled);
+        engine.set_voice_leading_style(preset.voice_leading_style);
+        engine.set_scale_mode(preset.scale_mode);
+        engine.set_interchange_enabled(preset.interchange_enabled);
+        engine.set_borrowing_range(preset.borrowing_range);
+    }
+
+    // Mirror `raise_panic` from commands/harmony.rs — each of the 8
+    // setters above stashed held inputs into `pending_reharm_inputs`
+    // via `clear_active_for_reharm`. Without raising the panic flag
+    // the router's reharm-diff replay never fires, so external synths
+    // hold the prior preset's harmony forever (stuck-MIDI-notes on
+    // preset switch). 5-line miss that broke a major user flow.
+    state.panic_pending.store(true, Ordering::SeqCst);
+
+    Ok(())
+}
 
 /// Saves the current engine config as a custom preset, both in-memory
 /// and to the disk as a .cpk file.
@@ -31,12 +119,10 @@ pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
     manager.add_custom(style.clone());
 
     // 3. Assemble the full payload (Fixes Reviewer Point #2)
-    // Using empty JSON objects for missing states to satisfy the struct without circular imports.
-    // In a full implementation, these would pull from AppState.
     let payload = ContrapunkPresetPayload {
         version: 1,
         style,
-        voice_count: engine.voice_count(), // Assuming voice_count() is exposed on the engine
+        voice_count: engine.voice_count(),
         mixer: json!({}),
         tuning: json!({}),
         routing: json!({}),
@@ -45,7 +131,6 @@ pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
     };
 
     // 4. Save to disk (Fixes Reviewer Point #1)
-    // We default to saving in the current working directory for now.
     let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let file_name = format!("{}.cpk", name.replace(" ", "_").to_lowercase());
     let file_path = current_dir.join(file_name);
@@ -53,4 +138,58 @@ pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
     save_preset_to_file(&payload, &file_path).map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+/// Deletes a custom preset by name.
+#[tauri::command]
+pub fn delete_preset(name: String, state: State<AppState>) -> Result<(), String> {
+    let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
+
+    // Find index in custom presets
+    let custom = manager.custom_presets();
+    let idx = custom
+        .iter()
+        .position(|p| p.name == name)
+        .ok_or_else(|| format!("Custom preset not found: {}", name))?;
+
+    manager.remove_custom(idx);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn load_preset_raises_panic_pending() {
+        let state = AppState::default();
+        state.panic_pending.store(false, Ordering::SeqCst);
+
+        let preset_name = {
+            let manager = state.preset_manager.lock().unwrap();
+            let all = manager.all_presets();
+            assert!(!all.is_empty(), "default AppState should ship builtins");
+            all[0].name.clone()
+        };
+
+        apply_preset_inner(&state, &preset_name).expect("load_preset failed");
+        assert!(
+            state.panic_pending.load(Ordering::SeqCst),
+            "load_preset must raise panic_pending"
+        );
+    }
+
+    #[test]
+    fn load_preset_unknown_name_does_not_raise_panic() {
+        let state = AppState::default();
+        state.panic_pending.store(false, Ordering::SeqCst);
+
+        let result = apply_preset_inner(&state, "nonexistent-preset-zzz");
+        assert!(result.is_err(), "unknown preset must return Err");
+        assert!(
+            !state.panic_pending.load(Ordering::SeqCst),
+            "failed load must not raise panic"
+        );
+    }
 }

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 
 use serde::Serialize;
 use serde_json::json;
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 
 use contrapunk::preset::storage::save_preset_to_file;
 use contrapunk::preset::ContrapunkPresetPayload;
@@ -95,7 +95,7 @@ pub(crate) fn apply_preset_inner(state: &AppState, name: &str) -> Result<(), Str
 /// Saves the current engine config as a custom preset, both in-memory
 /// and to the disk as a .cpk file.
 #[tauri::command]
-pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
+pub fn save_preset(name: String, state: State<AppState>, app: AppHandle) -> Result<(), String> {
     let engine = state.engine.lock().map_err(|e| e.to_string())?;
 
     // 1. Create the core StylePreset
@@ -131,9 +131,22 @@ pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
     };
 
     // 4. Save to disk (Fixes Reviewer Point #1)
-    let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    // Fetch the secure OS-level AppData directory managed by Tauri
+    let mut file_path = app
+        .path()
+        .app_data_dir()
+        .map_err(|_| "Cannot find AppData dir".to_string())?;
+
+    // Append a dedicated "presets" folder to organize files cleanly
+    file_path.push("presets");
+
+    // Ensure the folder actually exists before writing, avoiding silent path errors
+    std::fs::create_dir_all(&file_path).map_err(|e| e.to_string())?;
+
+    // Format the filename and push it to the path
     let file_name = format!("{}.cpk", name.replace(" ", "_").to_lowercase());
-    let file_path = current_dir.join(file_name);
+    file_path.push(file_name);
 
     save_preset_to_file(&payload, &file_path).map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -2,19 +2,21 @@
 //!
 //! List, load, save, and delete presets.
 
-use std::env;
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 
 use serde::Serialize;
-use serde_json::json;
 use tauri::{AppHandle, Manager, State};
 
-use contrapunk::preset::storage::save_preset_to_file;
-use contrapunk::preset::ContrapunkPresetPayload;
+use contrapunk::preset::storage::{load_preset_from_file, save_preset_to_file};
 use contrapunk::preset::StylePreset;
 
 use crate::state::AppState;
+
+const MAX_PRESET_NAME_BYTES: usize = 80;
 
 /// Serializable preset info for the frontend.
 #[derive(Serialize)]
@@ -26,9 +28,138 @@ pub struct PresetInfo {
     pub is_builtin: bool,
 }
 
-/// Lists all available presets (builtins + custom).
+fn normalize_preset_name(name: &str) -> Result<String, String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("Preset name cannot be empty".into());
+    }
+    if name.len() > MAX_PRESET_NAME_BYTES {
+        return Err(format!(
+            "Preset name cannot exceed {MAX_PRESET_NAME_BYTES} bytes"
+        ));
+    }
+    if name.chars().any(char::is_control) {
+        return Err("Preset name cannot contain control characters".into());
+    }
+    Ok(name.to_owned())
+}
+
+/// Encodes every path-significant byte while keeping ordinary names readable.
+fn preset_file_name(name: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(name.len() * 3 + 11);
+    encoded.push_str("preset-");
+    for &byte in name.as_bytes() {
+        match byte {
+            b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' => encoded.push(byte as char),
+            _ => {
+                encoded.push('~');
+                encoded.push(HEX[(byte >> 4) as usize] as char);
+                encoded.push(HEX[(byte & 0x0f) as usize] as char);
+            }
+        }
+    }
+    encoded.push_str(".cpk");
+    encoded
+}
+
+fn presets_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|path| path.join("presets"))
+        .map_err(|error| format!("Cannot find app data directory: {error}"))
+}
+
+fn is_cpk_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("cpk"))
+}
+
+fn preset_files_in(directory: &Path) -> Result<Vec<PathBuf>, String> {
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    let mut files = Vec::new();
+    for entry in entries {
+        let path = entry.map_err(|error| error.to_string())?.path();
+        if is_cpk_file(&path) {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn load_custom_presets_from_dir(directory: &Path) -> Result<Vec<StylePreset>, String> {
+    let mut loaded = Vec::new();
+    for path in preset_files_in(directory)? {
+        match load_preset_from_file(&path) {
+            Ok(mut preset) => match normalize_preset_name(&preset.name) {
+                Ok(name) => {
+                    preset.name = name;
+                    loaded.push(preset);
+                }
+                Err(error) => eprintln!("[presets] skipping {}: {error}", path.display()),
+            },
+            Err(error) => eprintln!("[presets] skipping {}: {error}", path.display()),
+        }
+    }
+    Ok(loaded)
+}
+
+fn refresh_custom_presets(app: &AppHandle, state: &AppState) -> Result<(), String> {
+    let mut loaded = load_custom_presets_from_dir(&presets_dir(app)?)?;
+    let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
+    let mut names: HashSet<String> = manager
+        .all_presets()
+        .into_iter()
+        .filter(|preset| preset.is_builtin)
+        .map(|preset| preset.name.clone())
+        .collect();
+    loaded.retain(|preset| {
+        if names.insert(preset.name.clone()) {
+            true
+        } else {
+            eprintln!("[presets] skipping duplicate preset: {}", preset.name);
+            false
+        }
+    });
+    manager.set_custom_presets(loaded);
+    Ok(())
+}
+
+fn preset_file_for_name_in(directory: &Path, name: &str) -> Result<PathBuf, String> {
+    let expected = directory.join(preset_file_name(name));
+    let matches_name = |path: &Path| {
+        load_preset_from_file(path)
+            .ok()
+            .and_then(|preset| normalize_preset_name(&preset.name).ok())
+            .is_some_and(|stored_name| stored_name == name)
+    };
+    if expected.is_file() && matches_name(&expected) {
+        return Ok(expected);
+    }
+
+    for path in preset_files_in(directory)? {
+        if matches_name(&path) {
+            return Ok(path);
+        }
+    }
+    Err(format!("Preset file not found: {name}"))
+}
+
+fn preset_file_for_name(app: &AppHandle, name: &str) -> Result<PathBuf, String> {
+    preset_file_for_name_in(&presets_dir(app)?, name)
+}
+
+/// Lists all available presets (builtins + persisted custom styles).
 #[tauri::command]
-pub fn list_presets(state: State<AppState>) -> Result<Vec<PresetInfo>, String> {
+pub fn list_presets(app: AppHandle, state: State<AppState>) -> Result<Vec<PresetInfo>, String> {
+    refresh_custom_presets(&app, &state)?;
     let manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
     let presets = manager.all_presets();
     Ok(presets
@@ -46,7 +177,9 @@ pub fn list_presets(state: State<AppState>) -> Result<Vec<PresetInfo>, String> {
 
 /// Loads a preset by name and applies it to the engine.
 #[tauri::command]
-pub fn load_preset(name: String, state: State<AppState>) -> Result<(), String> {
+pub fn load_preset(name: String, app: AppHandle, state: State<AppState>) -> Result<(), String> {
+    let name = normalize_preset_name(&name)?;
+    refresh_custom_presets(&app, &state)?;
     apply_preset_inner(&state, &name)
 }
 
@@ -92,79 +225,74 @@ pub(crate) fn apply_preset_inner(state: &AppState, name: &str) -> Result<(), Str
     Ok(())
 }
 
-/// Saves the current engine config as a custom preset, both in-memory
-/// and to the disk as a .cpk file.
+/// Saves the current harmony style as a custom `.cpk` preset.
 #[tauri::command]
-pub fn save_preset(name: String, state: State<AppState>, app: AppHandle) -> Result<(), String> {
-    let engine = state.engine.lock().map_err(|e| e.to_string())?;
+pub fn save_preset(name: String, app: AppHandle, state: State<AppState>) -> Result<(), String> {
+    refresh_custom_presets(&app, &state)?;
+    let name = normalize_preset_name(&name)?;
+    {
+        let manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
+        if manager
+            .all_presets()
+            .into_iter()
+            .any(|preset| preset.name == name)
+        {
+            return Err(format!("Preset already exists: {name}"));
+        }
+    }
 
-    // 1. Create the core StylePreset
-    let style = StylePreset {
-        name: name.clone(),
-        persona: "Custom".to_string(),
-        genre: "Custom".to_string(),
-        harmony_mode: engine.mode(),
-        key: engine.key(),
-        voice_leading_enabled: engine.voice_leading_enabled(),
-        voice_leading_style: engine.voice_leading_style(),
-        octave_mode: engine.octave_mode(),
-        scale_mode: engine.scale_mode(),
-        interchange_enabled: engine.interchange_enabled(),
-        borrowing_range: engine.borrowing_range(),
-        is_builtin: false,
+    let preset = {
+        let engine = state.engine.lock().map_err(|e| e.to_string())?;
+        StylePreset {
+            name: name.clone(),
+            persona: "Custom".to_string(),
+            genre: "Custom".to_string(),
+            harmony_mode: engine.mode(),
+            key: engine.key(),
+            voice_leading_enabled: engine.voice_leading_enabled(),
+            voice_leading_style: engine.voice_leading_style(),
+            octave_mode: engine.octave_mode(),
+            scale_mode: engine.scale_mode(),
+            interchange_enabled: engine.interchange_enabled(),
+            borrowing_range: engine.borrowing_range(),
+            is_builtin: false,
+        }
     };
 
-    // 2. Add to in-memory manager (Existing logic)
+    let directory = presets_dir(&app)?;
+    fs::create_dir_all(&directory).map_err(|error| error.to_string())?;
+    save_preset_to_file(&preset, &directory.join(preset_file_name(&name)))
+        .map_err(|error| error.to_string())?;
+
     let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
-    manager.add_custom(style.clone());
-
-    // 3. Assemble the full payload (Fixes Reviewer Point #2)
-    let payload = ContrapunkPresetPayload {
-        version: 1,
-        style,
-        voice_count: engine.voice_count(),
-        mixer: json!({}),
-        tuning: json!({}),
-        routing: json!({}),
-        slide_enabled: false,
-        companion: json!({}),
-    };
-
-    // 4. Save to disk (Fixes Reviewer Point #1)
-
-    // Fetch the secure OS-level AppData directory managed by Tauri
-    let mut file_path = app
-        .path()
-        .app_data_dir()
-        .map_err(|_| "Cannot find AppData dir".to_string())?;
-
-    // Append a dedicated "presets" folder to organize files cleanly
-    file_path.push("presets");
-
-    // Ensure the folder actually exists before writing, avoiding silent path errors
-    std::fs::create_dir_all(&file_path).map_err(|e| e.to_string())?;
-
-    // Format the filename and push it to the path
-    let file_name = format!("{}.cpk", name.replace(" ", "_").to_lowercase());
-    file_path.push(file_name);
-
-    save_preset_to_file(&payload, &file_path).map_err(|e| e.to_string())?;
-
+    manager.add_custom(preset);
     Ok(())
 }
 
-/// Deletes a custom preset by name.
+/// Deletes a persisted custom preset by name.
 #[tauri::command]
-pub fn delete_preset(name: String, state: State<AppState>) -> Result<(), String> {
+pub fn delete_preset(name: String, app: AppHandle, state: State<AppState>) -> Result<(), String> {
+    refresh_custom_presets(&app, &state)?;
+    let name = normalize_preset_name(&name)?;
+    {
+        let manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
+        if !manager
+            .custom_presets()
+            .iter()
+            .any(|preset| preset.name == name)
+        {
+            return Err(format!("Custom preset not found: {name}"));
+        }
+    }
+
+    fs::remove_file(preset_file_for_name(&app, &name)?).map_err(|error| error.to_string())?;
+
     let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
-
-    // Find index in custom presets
-    let custom = manager.custom_presets();
-    let idx = custom
+    let idx = manager
+        .custom_presets()
         .iter()
-        .position(|p| p.name == name)
-        .ok_or_else(|| format!("Custom preset not found: {}", name))?;
-
+        .position(|preset| preset.name == name)
+        .ok_or_else(|| format!("Custom preset not found: {name}"))?;
     manager.remove_custom(idx);
     Ok(())
 }
@@ -172,13 +300,57 @@ pub fn delete_preset(name: String, state: State<AppState>) -> Result<(), String>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
+    static TEST_DIR_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "contrapunk-tauri-presets-{}-{}",
+                std::process::id(),
+                TEST_DIR_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn custom_preset(name: &str) -> StylePreset {
+        let state = AppState::default();
+        let manager = state.preset_manager.lock().unwrap();
+        let mut preset = manager.all_presets()[0].clone();
+        preset.name = name.into();
+        preset.is_builtin = false;
+        preset
+    }
+
+    /// Regression for commit `b065eb5`: `load_preset` must raise
+    /// `panic_pending` so the router-loop drain sends NoteOffs for
+    /// stale harmonies after the engine setters mutate. Without this,
+    /// external synths hold the prior preset's harmony forever
+    /// (stuck-MIDI-notes on preset switch). The fix is one line; the
+    /// hole was 5 months old.
+    ///
+    /// Test mirrors the structural contract: after `apply_preset_inner`
+    /// returns, `state.panic_pending` MUST be `true`. The router-loop
+    /// drain itself (engine.rs:463-558) is tested separately via the
+    /// `drain_all_tracked_notes` cases.
     #[test]
     fn load_preset_raises_panic_pending() {
         let state = AppState::default();
         state.panic_pending.store(false, Ordering::SeqCst);
 
+        // Find any builtin preset to load — the specific contents
+        // don't matter, only the side-effect.
         let preset_name = {
             let manager = state.preset_manager.lock().unwrap();
             let all = manager.all_presets();
@@ -189,10 +361,16 @@ mod tests {
         apply_preset_inner(&state, &preset_name).expect("load_preset failed");
         assert!(
             state.panic_pending.load(Ordering::SeqCst),
-            "load_preset must raise panic_pending"
+            "load_preset must raise panic_pending — without it, stale \
+             harmonies stay stuck on external synths after preset switch"
         );
     }
 
+    /// Negative regression: if someone deletes the
+    /// `state.panic_pending.store(true, ...)` line in `apply_preset_inner`,
+    /// the test above fires. This second case nails down the
+    /// no-op-on-error contract: loading an unknown preset must NOT
+    /// raise panic (no engine mutation happened, no NoteOff needed).
     #[test]
     fn load_preset_unknown_name_does_not_raise_panic() {
         let state = AppState::default();
@@ -202,7 +380,41 @@ mod tests {
         assert!(result.is_err(), "unknown preset must return Err");
         assert!(
             !state.panic_pending.load(Ordering::SeqCst),
-            "failed load must not raise panic"
+            "failed load must not raise panic — nothing changed"
         );
+    }
+
+    #[test]
+    fn preset_names_cannot_escape_or_collide() {
+        assert_eq!(
+            preset_file_name("../My Preset/🎵"),
+            "preset-~2e~2e~2f~4dy~20~50reset~2f~f0~9f~8e~b5.cpk"
+        );
+        assert_ne!(preset_file_name("My Preset"), preset_file_name("my_preset"));
+        assert_ne!(preset_file_name("A"), preset_file_name("a"));
+        assert!(normalize_preset_name("  ").is_err());
+        assert!(normalize_preset_name("bad\nname").is_err());
+        assert!(normalize_preset_name(&"x".repeat(MAX_PRESET_NAME_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn persisted_presets_survive_reload_and_delete_from_disk() {
+        let dir = TestDir::new();
+        let preset = custom_preset("Saved Style");
+        let expected_path = dir.0.join(preset_file_name(&preset.name));
+        save_preset_to_file(&custom_preset("Different Style"), &expected_path).unwrap();
+        let imported_path = dir.0.join("shared-file.cpk");
+        save_preset_to_file(&preset, &imported_path).unwrap();
+
+        let loaded = load_custom_presets_from_dir(&dir.0).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert!(loaded.iter().any(|loaded| loaded.name == preset.name));
+
+        let stored_path = preset_file_for_name_in(&dir.0, &preset.name).unwrap();
+        assert_eq!(stored_path, imported_path);
+        fs::remove_file(stored_path).unwrap();
+        let remaining = load_custom_presets_from_dir(&dir.0).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].name, "Different Style");
     }
 }

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -1,98 +1,17 @@
-//! Tauri commands for preset management.
-//!
-//! List, load, save, and delete presets.
+use contrapunk::preset::storage::save_preset_to_file;
+use contrapunk::preset::ContrapunkPresetPayload;
+use serde_json::json;
+use std::env;
+use std::path::PathBuf;
 
-use std::sync::atomic::Ordering;
-
-use serde::Serialize;
-use tauri::State;
-
-use contrapunk::preset::StylePreset;
-
-use crate::state::AppState;
-
-/// Serializable preset info for the frontend.
-#[derive(Serialize)]
-pub struct PresetInfo {
-    pub index: usize,
-    pub name: String,
-    pub persona: String,
-    pub genre: String,
-    pub is_builtin: bool,
-}
-
-/// Lists all available presets (builtins + custom).
-#[tauri::command]
-pub fn list_presets(state: State<AppState>) -> Result<Vec<PresetInfo>, String> {
-    let manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
-    let presets = manager.all_presets();
-    Ok(presets
-        .iter()
-        .enumerate()
-        .map(|(i, p)| PresetInfo {
-            index: i,
-            name: p.name.clone(),
-            persona: p.persona.clone(),
-            genre: p.genre.clone(),
-            is_builtin: p.is_builtin,
-        })
-        .collect())
-}
-
-/// Loads a preset by name and applies it to the engine.
-#[tauri::command]
-pub fn load_preset(name: String, state: State<AppState>) -> Result<(), String> {
-    apply_preset_inner(&state, &name)
-}
-
-/// Inner implementation of `load_preset` that operates on a plain
-/// `&AppState` reference. Extracted from the Tauri command wrapper so
-/// the regression test can exercise the full reharm path without
-/// standing up a `tauri::State`.
-pub(crate) fn apply_preset_inner(state: &AppState, name: &str) -> Result<(), String> {
-    let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
-
-    // Find preset by name — two-phase to avoid borrow conflict
-    let (idx, preset) = {
-        let all = manager.all_presets();
-        let found = all.iter().enumerate().find(|(_, p)| p.name == name);
-        match found {
-            Some((idx, p)) => (idx, (*p).clone()),
-            None => return Err(format!("Preset not found: {}", name)),
-        }
-    };
-    manager.set_active(idx);
-
-    // Apply preset to engine
-    {
-        let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
-        engine.set_key(preset.key);
-        engine.set_mode(preset.harmony_mode);
-        engine.set_octave_mode(preset.octave_mode);
-        engine.set_voice_leading_enabled(preset.voice_leading_enabled);
-        engine.set_voice_leading_style(preset.voice_leading_style);
-        engine.set_scale_mode(preset.scale_mode);
-        engine.set_interchange_enabled(preset.interchange_enabled);
-        engine.set_borrowing_range(preset.borrowing_range);
-    }
-
-    // Mirror `raise_panic` from commands/harmony.rs — each of the 8
-    // setters above stashed held inputs into `pending_reharm_inputs`
-    // via `clear_active_for_reharm`. Without raising the panic flag
-    // the router's reharm-diff replay never fires, so external synths
-    // hold the prior preset's harmony forever (stuck-MIDI-notes on
-    // preset switch). 5-line miss that broke a major user flow.
-    state.panic_pending.store(true, Ordering::SeqCst);
-
-    Ok(())
-}
-
-/// Saves the current engine config as a custom preset.
+/// Saves the current engine config as a custom preset, both in-memory
+/// and to the disk as a .cpk file.
 #[tauri::command]
 pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
     let engine = state.engine.lock().map_err(|e| e.to_string())?;
 
-    let preset = StylePreset {
+    // 1. Create the core StylePreset
+    let style = StylePreset {
         name: name.clone(),
         persona: "Custom".to_string(),
         genre: "Custom".to_string(),
@@ -107,80 +26,31 @@ pub fn save_preset(name: String, state: State<AppState>) -> Result<(), String> {
         is_builtin: false,
     };
 
+    // 2. Add to in-memory manager (Existing logic)
     let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
-    manager.add_custom(preset);
+    manager.add_custom(style.clone());
+
+    // 3. Assemble the full payload (Fixes Reviewer Point #2)
+    // Using empty JSON objects for missing states to satisfy the struct without circular imports.
+    // In a full implementation, these would pull from AppState.
+    let payload = ContrapunkPresetPayload {
+        version: 1,
+        style,
+        voice_count: engine.voice_count(), // Assuming voice_count() is exposed on the engine
+        mixer: json!({}),
+        tuning: json!({}),
+        routing: json!({}),
+        slide_enabled: false,
+        companion: json!({}),
+    };
+
+    // 4. Save to disk (Fixes Reviewer Point #1)
+    // We default to saving in the current working directory for now.
+    let current_dir = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let file_name = format!("{}.cpk", name.replace(" ", "_").to_lowercase());
+    let file_path = current_dir.join(file_name);
+
+    save_preset_to_file(&payload, &file_path).map_err(|e| e.to_string())?;
+
     Ok(())
-}
-
-/// Deletes a custom preset by name.
-#[tauri::command]
-pub fn delete_preset(name: String, state: State<AppState>) -> Result<(), String> {
-    let mut manager = state.preset_manager.lock().map_err(|e| e.to_string())?;
-
-    // Find index in custom presets
-    let custom = manager.custom_presets();
-    let idx = custom
-        .iter()
-        .position(|p| p.name == name)
-        .ok_or_else(|| format!("Custom preset not found: {}", name))?;
-
-    manager.remove_custom(idx);
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::Ordering;
-
-    /// Regression for commit `b065eb5`: `load_preset` must raise
-    /// `panic_pending` so the router-loop drain sends NoteOffs for
-    /// stale harmonies after the engine setters mutate. Without this,
-    /// external synths hold the prior preset's harmony forever
-    /// (stuck-MIDI-notes on preset switch). The fix is one line; the
-    /// hole was 5 months old.
-    ///
-    /// Test mirrors the structural contract: after `apply_preset_inner`
-    /// returns, `state.panic_pending` MUST be `true`. The router-loop
-    /// drain itself (engine.rs:463-558) is tested separately via the
-    /// `drain_all_tracked_notes` cases.
-    #[test]
-    fn load_preset_raises_panic_pending() {
-        let state = AppState::default();
-        state.panic_pending.store(false, Ordering::SeqCst);
-
-        // Find any builtin preset to load — the specific contents
-        // don't matter, only the side-effect.
-        let preset_name = {
-            let manager = state.preset_manager.lock().unwrap();
-            let all = manager.all_presets();
-            assert!(!all.is_empty(), "default AppState should ship builtins");
-            all[0].name.clone()
-        };
-
-        apply_preset_inner(&state, &preset_name).expect("load_preset failed");
-        assert!(
-            state.panic_pending.load(Ordering::SeqCst),
-            "load_preset must raise panic_pending — without it, stale \
-             harmonies stay stuck on external synths after preset switch"
-        );
-    }
-
-    /// Negative regression: if someone deletes the
-    /// `state.panic_pending.store(true, ...)` line in `apply_preset_inner`,
-    /// the test above fires. This second case nails down the
-    /// no-op-on-error contract: loading an unknown preset must NOT
-    /// raise panic (no engine mutation happened, no NoteOff needed).
-    #[test]
-    fn load_preset_unknown_name_does_not_raise_panic() {
-        let state = AppState::default();
-        state.panic_pending.store(false, Ordering::SeqCst);
-
-        let result = apply_preset_inner(&state, "nonexistent-preset-zzz");
-        assert!(result.is_err(), "unknown preset must return Err");
-        assert!(
-            !state.panic_pending.load(Ordering::SeqCst),
-            "failed load must not raise panic — nothing changed"
-        );
-    }
 }


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

- Rebase the preset work onto current `main`, keeping the canonical workspace and dropping the unrelated macOS workflow change.
- Persist desktop custom harmony-style presets as versioned `.cpk` files under the Tauri app-data directory.
- Reload persisted presets before list, load, save, and delete operations so they survive restarts.
- Delete the corresponding file when a custom preset is removed.
- Validate and reversibly encode bounded preset names so user input cannot escape the preset directory or collide on case-insensitive filesystems.
- Install fully written files without clobbering an existing preset, and preserve the existing file when saving fails.
- Remove placeholder “full plug-in state” fields that serialized empty mixer, tuning, routing, Slide, and Companion data.
- Add round-trip, version, no-clobber, path-safety, reload, renamed-file, and disk-deletion regressions.
- Document the precise desktop harmony-style scope in `README.md`.

Refs #156. This PR delivers persistent desktop harmony-style presets; complete DAW plug-in/synth/routing/Slide/Companion state export remains separate work.

Validation:

- `cargo test -p contrapunk-preset` — 3 passed
- `cargo test -p contrapunk-tauri -- --nocapture` — 47 passed
- `cargo check --workspace --message-format=short` — passed with existing warnings
- `npm --prefix ui run check` — 0 errors, 13 existing warnings
- `cargo fmt --all -- --check`
- `git diff --check`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](CONTRIBUTING.md) included if any functionality added or changed
- [x] Pre-commit hook passes (`cp scripts/pre-commit .git/hooks/pre-commit` to install)
- [x] Follows the commit message standard (`feat`/`fix`/`refactor`/`docs` prefix)
- [x] Has a kind label (`kind/bug`, `kind/feature`, `kind/cleanup`, `kind/docs`)
- [x] User-facing changes documented in README or relevant docs
- [x] Release notes block below updated with any user-facing changes

# Release Notes

```release-note
Desktop custom harmony-style presets now persist across restarts as versioned `.cpk` files.
```
