### PR TITLE
refactor(ui): remove static synth metadata

### DIFF
--- a/ui/src/lib/components/elixir/OscillatorPanel.svelte
+++ b/ui/src/lib/components/elixir/OscillatorPanel.svelte
@@ -14,12 +14,6 @@
 			</svg>
 		</div>
 
-		<div class="parameter-list">
-			<div><span>Waveform</span><strong>Sine</strong></div>
-			<div><span>Voices</span><strong>16</strong></div>
-			<div><span>Pitch</span><strong>Exact Hz</strong></div>
-			<div><span>Ramp</span><strong>5 ms</strong></div>
-		</div>
 	</div>
 </section>
 
@@ -46,19 +40,4 @@
 	.grid { fill: none; stroke: #242424; stroke-width: 1; }
 	.axis { fill: none; stroke: #383838; stroke-width: 1; }
 	.wave { fill: none; stroke: #8aaac0; stroke-width: 2; vector-effect: non-scaling-stroke; }
-	.parameter-list {
-		display: grid;
-		grid-template-columns: repeat(4, 1fr);
-		border: 1px solid #3b3b3b;
-		border-top: 0;
-	}
-	.parameter-list div { min-width: 0; padding: 10px; border-right: 1px solid #3b3b3b; display: grid; gap: 3px; }
-	.parameter-list div:last-child { border-right: 0; }
-	.parameter-list span { color: #777; font: 10px var(--font-ui); }
-	.parameter-list strong { color: #c8c8c8; font: 500 12px var(--font-ui); }
-	@media (max-width: 600px) {
-		.parameter-list { grid-template-columns: repeat(2, 1fr); }
-		.parameter-list div:nth-child(2) { border-right: 0; }
-		.parameter-list div:nth-child(-n + 2) { border-bottom: 1px solid #3b3b3b; }
-	}
 </style>


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

Remove the static `Waveform / Voices / Pitch / Ramp` metadata row from the Elixir oscillator view. These values were informational duplicates rather than controls; the oscillator visualization and synth behavior remain unchanged.

Validation:

- `npm --prefix ui run check` — 0 errors, 13 existing warnings
- `git diff --check`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](CONTRIBUTING.md) included if any functionality added or changed (display-only deletion; Svelte check covers compilation)
- [x] Pre-commit hook passes (`cp scripts/pre-commit .git/hooks/pre-commit` to install)
- [x] Follows the commit message standard (`feat`/`fix`/`refactor`/`docs` prefix)
- [x] Has a kind label (`kind/bug`, `kind/feature`, `kind/cleanup`, `kind/docs`)
- [x] User-facing changes documented in README or relevant docs (no usage instructions changed)
- [x] Release notes block below updated with any user-facing changes

# Release Notes

```release-note
Removed redundant static technical metadata from the Elixir oscillator view.
```
