### PR TITLE
fix(ui): keep Elixir as the single synth mixer

### DIFF
--- a/src-tauri/src/commands/routing.rs
+++ b/src-tauri/src/commands/routing.rs
@@ -36,6 +36,21 @@ pub fn set_voice_output(
     Ok(())
 }
 
+/// Temporarily send every part to the internal synth without replacing the
+/// user's per-part assignments.
+#[tauri::command]
+pub fn set_all_voice_outputs_to_synth(enabled: bool, state: State<AppState>) -> Result<(), String> {
+    let changed = state
+        .voice_outputs
+        .lock()
+        .map_err(|e| e.to_string())?
+        .set_all_to_synth(enabled);
+    if changed {
+        state.route_change_pending.store(true, Ordering::Release);
+    }
+    Ok(())
+}
+
 /// Return only non-default assignments. Missing routes resolve to Synth.
 #[tauri::command]
 pub fn get_voice_outputs(state: State<AppState>) -> Result<Vec<VoiceOutputAssignment>, String> {
@@ -102,6 +117,25 @@ mod tests {
         assert!(!routes.set(canon, VoiceOutputTarget::MidiPort { port: 2 }));
         assert!(routes.set(canon, VoiceOutputTarget::Synth));
         assert_eq!(routes.get(canon), VoiceOutputTarget::Synth);
+    }
+
+    #[test]
+    fn all_synth_override_preserves_user_assignments() {
+        let mut routes = crate::state::VoiceOutputRoutes::default();
+        let input = VoiceRouteId::Input;
+        let canon = VoiceRouteId::Canon { voice: 0 };
+        routes.set(input, VoiceOutputTarget::MidiPort { port: 2 });
+        routes.set(canon, VoiceOutputTarget::Off);
+
+        assert!(routes.set_all_to_synth(true));
+        assert_eq!(routes.get(input), VoiceOutputTarget::Synth);
+        assert_eq!(routes.get(canon), VoiceOutputTarget::Synth);
+        assert!(!routes.has_external_target());
+
+        assert!(routes.set_all_to_synth(false));
+        assert_eq!(routes.get(input), VoiceOutputTarget::MidiPort { port: 2 });
+        assert_eq!(routes.get(canon), VoiceOutputTarget::Off);
+        assert!(routes.has_external_target());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,6 +142,7 @@ fn main() {
             commands::engine::panic_all_notes_off,
             // Per-voice output routing
             commands::routing::set_voice_output,
+            commands::routing::set_all_voice_outputs_to_synth,
             commands::routing::get_voice_outputs,
             // Guitar audio input
             commands::guitar::set_guitar_device,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -87,15 +87,24 @@ impl VoiceRouteId {
 #[derive(Clone, Debug, Default)]
 pub struct VoiceOutputRoutes {
     targets: HashMap<VoiceRouteId, VoiceOutputTarget>,
+    all_to_synth: bool,
 }
 
 impl VoiceOutputRoutes {
     pub fn get(&self, route: VoiceRouteId) -> VoiceOutputTarget {
+        if self.all_to_synth {
+            VoiceOutputTarget::Synth
+        } else {
+            self.configured_target(route)
+        }
+    }
+
+    fn configured_target(&self, route: VoiceRouteId) -> VoiceOutputTarget {
         self.targets.get(&route).copied().unwrap_or_default()
     }
 
     pub fn set(&mut self, route: VoiceRouteId, target: VoiceOutputTarget) -> bool {
-        if self.get(route) == target {
+        if self.configured_target(route) == target {
             return false;
         }
         if target == VoiceOutputTarget::Synth {
@@ -106,14 +115,24 @@ impl VoiceOutputRoutes {
         true
     }
 
+    pub fn set_all_to_synth(&mut self, enabled: bool) -> bool {
+        if self.all_to_synth == enabled {
+            return false;
+        }
+        self.all_to_synth = enabled;
+        true
+    }
+
     pub fn assignments(&self) -> impl Iterator<Item = (VoiceRouteId, VoiceOutputTarget)> + '_ {
         self.targets.iter().map(|(&route, &target)| (route, target))
     }
 
     pub fn has_external_target(&self) -> bool {
-        self.targets
-            .values()
-            .any(|target| matches!(target, VoiceOutputTarget::MidiPort { .. }))
+        !self.all_to_synth
+            && self
+                .targets
+                .values()
+                .any(|target| matches!(target, VoiceOutputTarget::MidiPort { .. }))
     }
 }
 

--- a/ui/src/lib/adapter/plugin.ts
+++ b/ui/src/lib/adapter/plugin.ts
@@ -418,6 +418,7 @@ export class PluginAdapter implements ContrapunkAdapter {
 		if (target.kind === 'synth') this._voiceOutputs.delete(route);
 		else this._voiceOutputs.set(route, target);
 	}
+	async setAllVoiceOutputsToSynth(_enabled: boolean): Promise<void> {}
 	async getVoiceOutputs(): Promise<VoiceOutputAssignment[]> {
 		return [...this._voiceOutputs].map(([route, target]) => ({ route, target }));
 	}

--- a/ui/src/lib/adapter/tauri.ts
+++ b/ui/src/lib/adapter/tauri.ts
@@ -656,6 +656,14 @@ export class TauriAdapter implements ContrapunkAdapter {
 		}
 	}
 
+	async setAllVoiceOutputsToSynth(enabled: boolean): Promise<void> {
+		try {
+			await invoke('set_all_voice_outputs_to_synth', { enabled });
+		} catch (e) {
+			throw new Error(`Failed to change global voice output: ${e}`);
+		}
+	}
+
 	async getVoiceOutputs(): Promise<VoiceOutputAssignment[]> {
 		try {
 			return (await invoke('get_voice_outputs')) as VoiceOutputAssignment[];

--- a/ui/src/lib/adapter/types.ts
+++ b/ui/src/lib/adapter/types.ts
@@ -560,6 +560,9 @@ export interface ContrapunkAdapter {
 	/** Set one stable musical part's destination. */
 	setVoiceOutput(route: VoiceRouteId, target: VoiceOutputTarget): Promise<void>;
 
+	/** Temporarily send every part to the synth without replacing its saved destination. */
+	setAllVoiceOutputsToSynth(enabled: boolean): Promise<void>;
+
 	/** Return non-default route assignments; omitted routes use the synth. */
 	getVoiceOutputs(): Promise<VoiceOutputAssignment[]>;
 

--- a/ui/src/lib/adapter/wasm.ts
+++ b/ui/src/lib/adapter/wasm.ts
@@ -1150,6 +1150,8 @@ export class WasmAdapter implements ContrapunkAdapter {
 		else this._voiceOutputs.set(route, target);
 	}
 
+	async setAllVoiceOutputsToSynth(_enabled: boolean): Promise<void> {}
+
 	async getVoiceOutputs(): Promise<VoiceOutputAssignment[]> {
 		return [...this._voiceOutputs].map(([route, target]) => ({ route, target }));
 	}

--- a/ui/src/lib/components/ChainPanel.svelte
+++ b/ui/src/lib/components/ChainPanel.svelte
@@ -8,6 +8,7 @@
 	import ClapPluginPicker from './ClapPluginPicker.svelte';
 
 	let pickerOpen = $state(false);
+	let audioBlocks = $derived(chainStore.blocks.filter((block) => block.typeId !== 'builtin.synth'));
 
 	onMount(() => {
 		reverb.syncFromBackend();
@@ -19,25 +20,22 @@
 <div class="chain-wrap">
 	<div class="chain-header-row">
 		<div class="chain-header font-ui">Audio chain</div>
-		<button class="pixel-btn font-ui add-plugin-btn" onclick={() => (pickerOpen = true)}>
-			+ Plugin
-		</button>
+		{#if adapter.capabilities.chainEditor}
+			<button class="pixel-btn font-ui add-plugin-btn" onclick={() => (pickerOpen = true)}>
+				+ Plugin
+			</button>
+		{/if}
 	</div>
 
-	<!-- Signal-flow strip: dynamic based on chain state -->
+	<!-- The Synth view owns levels; this strip only summarizes its output into the FX chain. -->
 	<div class="flow">
 		<div class="flow-node source font-ui">
-			<div class="flow-title">Harmony</div>
-			<div class="flow-sub">MIDI</div>
+			<div class="flow-title">Elixir</div>
+			<div class="flow-sub">{synth.enabled ? 'from Synth view' : 'muted in Synth view'}</div>
 		</div>
-		{#each chainStore.blocks as b, i (i + ':' + b.typeId)}
+		{#each audioBlocks as b, i (i + ':' + b.typeId)}
 			<div class="flow-arrow font-ui">━━▶</div>
-			{#if b.typeId === 'builtin.synth'}
-				<div class="flow-node synth-node font-ui">
-					<div class="flow-title">Sine</div>
-					<div class="flow-sub">16-voice</div>
-				</div>
-			{:else if b.typeId === 'builtin.delay'}
+			{#if b.typeId === 'builtin.delay'}
 				<div class="flow-node delay-node font-ui" class:active={delay.enabled}>
 					<div class="flow-title">Delay</div>
 					<div class="flow-sub">{delay.enabled ? 'on' : 'bypass'}</div>
@@ -62,50 +60,8 @@
 		</div>
 	</div>
 
-	{#if adapter.capabilities.audioFx}
-	<!-- Synth rack: Serum-inspired -->
-	<div class="rack">
-		<div class="rack-header">
-			<span class="rack-title font-ui">Synth</span>
-			<button
-				class="pixel-btn power-btn font-ui"
-				class:active={synth.enabled}
-				onclick={() => synth.setEnabled(!synth.enabled)}
-				title={synth.enabled ? 'Bypass synth' : 'Enable synth'}
-			>
-				{synth.enabled ? 'ON' : 'OFF'}
-			</button>
-		</div>
-
-		<div class="rack-grid">
-			<section class="rack-section source-contract">
-				<div class="section-label font-ui">Source</div>
-				<strong class="font-code">SINE</strong>
-				<span class="font-code">16 voices · fixed 5 ms de-click</span>
-			</section>
-
-			<section class="rack-section amp">
-				<div class="section-label font-ui">Amp</div>
-				<div class="knob-row single">
-					<Knob
-						label="Master"
-						value={synth.masterGain}
-						min={0}
-						max={1}
-						step={0.01}
-						defaultValue={0.25}
-						format={(v) => `${Math.round(v * 100)}%`}
-						accent="var(--color-accent-gold)"
-						size={64}
-						onchange={(v) => synth.setMasterGain(v)}
-					/>
-				</div>
-			</section>
-		</div>
-
-	</div>
-
-	<ClapPluginPicker bind:open={pickerOpen} />
+	{#if adapter.capabilities.chainEditor}
+		<ClapPluginPicker bind:open={pickerOpen} />
 	{/if}
 
 	{#if adapter.capabilities.builtInFx}
@@ -364,11 +320,6 @@
 		color: var(--color-accent-cyan);
 	}
 
-	.flow-node.synth-node {
-		border-color: var(--color-accent-magenta-dim);
-		box-shadow: var(--glow-magenta);
-	}
-
 	.flow-node.plugin-node {
 		border-color: var(--color-accent-cyan-dim);
 		background: rgba(0, 60, 90, 0.5);
@@ -415,7 +366,7 @@
 		letter-spacing: -2px;
 	}
 
-	/* Synth rack */
+	/* Audio effect and plug-in racks */
 	.rack {
 		background: linear-gradient(180deg, #12101f, #0a0918);
 		border: 1px solid var(--color-border);
@@ -452,45 +403,6 @@
 		box-shadow: var(--glow-teal);
 		color: #ffffff;
 	}
-
-	.rack-grid {
-		display: grid;
-		grid-template-columns: 1fr auto;
-		gap: 8px;
-	}
-
-	.rack-section {
-		background: rgba(15, 14, 26, 0.5);
-		border: 1px solid var(--color-border);
-		padding: 6px 8px 8px;
-		display: flex;
-		flex-direction: column;
-		gap: 6px;
-	}
-
-	.section-label {
-		color: var(--color-text-secondary);
-		font-size: var(--font-size-xs);
-		letter-spacing: 1.5px;
-		text-transform: uppercase;
-		padding-bottom: 2px;
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.source-contract strong { color: var(--color-accent-cyan); font-size: var(--font-size-lg); letter-spacing: .12em; }
-	.source-contract span { color: var(--color-text-dim); font-size: var(--font-size-xs); }
-
-	.knob-row {
-		display: flex;
-		justify-content: space-around;
-		align-items: flex-start;
-		gap: 6px;
-	}
-
-	.knob-row.single {
-		justify-content: center;
-	}
-
 
 	/* Reverb rack */
 	.reverb-rack {
@@ -619,15 +531,4 @@
 		opacity: 0.35;
 	}
 
-	/* Collapse rack-grid on narrow windows */
-	@media (max-width: 980px) {
-		.rack-grid {
-			grid-template-columns: 1fr 1fr;
-		}
-	}
-	@media (max-width: 600px) {
-		.rack-grid {
-			grid-template-columns: 1fr;
-		}
-	}
 </style>

--- a/ui/src/lib/components/ContrapunkWorkspace.svelte
+++ b/ui/src/lib/components/ContrapunkWorkspace.svelte
@@ -81,6 +81,9 @@
 
 	onMount(() => {
 		let cancelled = false;
+		const unsubscribeSynth = adapter.capabilities.pluginMidiOutputMode
+			? adapter.onPluginParamsUpdate(() => void synth.syncFromBackend())
+			: () => {};
 		void (async () => {
 			try {
 				ui.restoreAppearance();
@@ -112,6 +115,7 @@
 		})();
 		return () => {
 			cancelled = true;
+			unsubscribeSynth();
 			void tone.stop();
 		};
 	});
@@ -167,9 +171,9 @@
 			<img src="/logo.svg" alt="Contrapunk" />
 			{#if adapter.capabilities.audioFx}
 				<nav class="view-tabs" aria-label="Main view">
-					<button class:active={activeView === 'harmony'} onclick={() => (activeView = 'harmony')}>Perform</button>
+					<button class:active={activeView === 'harmony'} aria-pressed={activeView === 'harmony'} onclick={() => (activeView = 'harmony')}>Perform</button>
 					<span aria-hidden="true">|</span>
-					<button class:active={activeView === 'synth'} onclick={() => (activeView = 'synth')}>Synth</button>
+					<button class:active={activeView === 'synth'} aria-pressed={activeView === 'synth'} onclick={() => (activeView = 'synth')}>Synth</button>
 				</nav>
 			{/if}
 		</div>
@@ -212,7 +216,7 @@
 			<div class="live-grid">
 				<ExpressionRoll />
 			</div>
-			<ArrangementMixer {openSetup} />
+			<ArrangementMixer {openSetup} openSynth={() => (activeView = 'synth')} />
 		{/if}
 	</main>
 	{/if}

--- a/ui/src/lib/components/OutputPanel.svelte
+++ b/ui/src/lib/components/OutputPanel.svelte
@@ -75,7 +75,7 @@
 	});
 
 	let outputOptions = $derived([
-		{ value: SYNTH_VALUE, label: 'Internal Synth' },
+		{ value: SYNTH_VALUE, label: 'Elixir Synth' },
 		...midi.outputs.map((device) => ({ value: String(device.index), label: device.name })),
 		{ value: OFF_VALUE, label: 'Off' }
 	]);
@@ -158,20 +158,18 @@
 		</div>
 	{/if}
 
-	{#if adapter.capabilities.audioFx || adapter.capabilities.chainEditor}
-		<!-- Synth + FX racks (absorbed from the legacy Chain tab).
-		     ChainPanel handles its own audioFx capability gating
-		     internally; we render it here whenever either flag is set. -->
+	{#if adapter.capabilities.builtInFx || adapter.capabilities.chainEditor}
+		<!-- The Synth view owns synth levels. Output renders the chain only
+		     when this surface can edit built-in effects or hosted plug-ins. -->
 		<ChainPanel />
 	{:else if !adapter.capabilities.perVoicePortRouting}
-		<!-- Plugin mode (audioFx=false, chainEditor=false,
-		     perVoicePortRouting=false) → without this hint the Output
-		     subtab would be just the static VGC card and a lot of empty
-		     space, leading users to think the tab is broken.
-		     Brutal-critic #7. -->
 		<div class="surface-unavailable font-ui">
-			Your DAW owns audio output and MIDI routing in plugin mode.
-			Use the host's mixer + plugin chain instead of these controls.
+			{#if adapter.capabilities.pluginMidiOutputMode}
+				Your DAW owns audio output and MIDI routing in plugin mode.
+				Use the host's mixer + plugin chain instead of these controls.
+			{:else}
+				The browser uses its built-in audio output and does not expose per-part MIDI destinations.
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/ui/src/lib/components/OutputPanel.svelte
+++ b/ui/src/lib/components/OutputPanel.svelte
@@ -112,10 +112,15 @@
 	}
 
 	function routeHasDestination(route: VoiceRouteId): boolean {
-		return midi.getVoiceOutput(route).kind !== 'off';
+		return midi.allVoiceOutputsToSynth || midi.getVoiceOutput(route).kind !== 'off';
 	}
 
 	function routeStatus(row: RouteRow): string {
+		if (midi.allVoiceOutputsToSynth) {
+			return row.active
+				? 'Part active; global destination is Elixir Synth'
+				: 'Part inactive; per-voice route assignment is preserved';
+		}
 		if (!row.active) return 'Part inactive; route assignment is preserved';
 		return routeHasDestination(row.route) ? 'Part active and routed' : 'Part active; destination is Off';
 	}
@@ -134,15 +139,26 @@
 		<div class="routing-section pixel-card">
 			<div class="output-header-row">
 				<span class="section-header font-ui">Per-voice routing</span>
-				<div title="Number of voices the engine generates">
-					<PixelSelect
-						options={voiceCountOptions}
-						value={String(engine.voiceCount)}
-						small={true}
-						onchange={onVoiceCountChange}
-					/>
+				<div class="header-controls">
+					<label class="all-synth-toggle font-ui" title="Temporarily send every part to Elixir without replacing the destinations below">
+						<input
+							type="checkbox"
+							checked={midi.allVoiceOutputsToSynth}
+							onchange={(event) => void midi.setAllVoiceOutputsToSynth(event.currentTarget.checked)}
+						/>
+						<span>All to Synth</span>
+					</label>
+					<div title="Number of voices the engine generates">
+						<PixelSelect
+							options={voiceCountOptions}
+							value={String(engine.voiceCount)}
+							small={true}
+							onchange={onVoiceCountChange}
+						/>
+					</div>
 				</div>
 			</div>
+			{#if midi.error}<p class="routing-error font-ui" role="alert">{midi.error}</p>{/if}
 			<div class="output-slots">
 				{#each routeSections as section (section.label)}
 					<div class="route-group font-code">{section.label}</div>
@@ -158,6 +174,8 @@
 								value={selectedOutput(row.route)}
 								placeholder="None"
 								small={true}
+								disabled={midi.allVoiceOutputsToSynth}
+								help={midi.allVoiceOutputsToSynth ? 'Turn off All to Synth to edit this saved destination' : undefined}
 								onchange={(value) => void handleOutputChange(row.route, value)}
 							/>
 						</div>
@@ -210,6 +228,28 @@
 		justify-content: space-between;
 		gap: 8px;
 		margin-bottom: 6px;
+	}
+
+	.header-controls,
+	.all-synth-toggle {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.all-synth-toggle {
+		color: var(--color-text-secondary);
+		font-size: var(--font-size-xs);
+		white-space: nowrap;
+		cursor: pointer;
+	}
+
+	.all-synth-toggle input { accent-color: var(--color-accent-cyan); }
+
+	.routing-error {
+		margin: 4px 0 6px;
+		color: #ff7a91;
+		font-size: var(--font-size-xs);
 	}
 
 	.output-slots {

--- a/ui/src/lib/components/OutputPanel.svelte
+++ b/ui/src/lib/components/OutputPanel.svelte
@@ -4,12 +4,13 @@
 	import { arrangement } from '$lib/stores/arrangement.svelte';
 	import { engine } from '$lib/stores/engine.svelte';
 	import { midi } from '$lib/stores/midi.svelte';
+	import { stableVoiceRoutes } from '$lib/routing/stable-voice-routes.mjs';
 	import ChainPanel from './ChainPanel.svelte';
 	import PixelSelect from './PixelSelect.svelte';
 
 	const SYNTH_VALUE = '__synth__';
 	const OFF_VALUE = '__off__';
-	type RouteRow = { route: VoiceRouteId; label: string };
+	type RouteRow = { route: VoiceRouteId; label: string; active: boolean };
 	type RouteSection = { label: string; rows: RouteRow[] };
 
 	const voiceCountOptions = Array.from({ length: MAX_VOICES }, (_, index) => index + 1).map(
@@ -27,51 +28,52 @@
 	}
 
 	let routeSections = $derived.by<RouteSection[]>(() => {
-		const sections: RouteSection[] = [
+		const rows = stableVoiceRoutes({
+			voiceCount: engine.voiceCount,
+			voicePosition: engine.voicePosition,
+			harmonyEnabled: engine.mode !== 'PassThrough',
+			companionEnabled: engine.companionEnabled,
+			canonVoiceCount: engine.canonVoices.length,
+			canonEnabled: engine.canonEnabled,
+			counterpointEnabled: arrangement.counterpoint.enabled,
+			phraseAware: arrangement.counterpoint.phraseAware,
+			patternLowEnabled: arrangement.patterns.lowSupport.enabled,
+			patternCounterEnabled: arrangement.patterns.counterline.enabled
+		}) as Array<{ section: string; route: VoiceRouteId; active: boolean }>;
+
+		const rowsFor = (section: string, label: (route: VoiceRouteId) => string): RouteRow[] =>
+			rows.filter((row) => row.section === section).map((row) => ({ ...row, label: label(row.route) }));
+		const routeIndex = (route: VoiceRouteId) => Number(route.split(':')[1]);
+
+		return [
 			{
 				label: 'Performed input',
-				rows: [{ route: 'input', label: `You (${registerName(engine.voicePosition)})` }]
-			}
-		];
-		const harmony = engine.mode === 'PassThrough'
-			? []
-			: Array.from({ length: engine.voiceCount }, (_, slot) => slot)
-					.filter((slot) => slot !== engine.voicePosition)
-					.map((slot) => ({
-						route: `harmony:${slot}` as VoiceRouteId,
-						label: `${registerName(slot)} harmony`
-					}));
-		if (harmony.length) sections.push({ label: 'Harmony', rows: harmony });
-
-		if (engine.companionEnabled && engine.canonEnabled && engine.canonVoices.length) {
-			sections.push({
+				rows: rowsFor('input', () => `You (${registerName(engine.voicePosition)})`)
+			},
+			{
+				label: 'Harmony',
+				rows: rowsFor('harmony', (route) => `${registerName(routeIndex(route))} harmony`)
+			},
+			{
 				label: 'Canon',
-				rows: engine.canonVoices.map((voice, index) => ({
-					route: `canon:${index}` as VoiceRouteId,
-					label: voice.preset_id ?? `Canon ${index + 1}`
-				}))
-			});
-		}
-		if (engine.companionEnabled && arrangement.counterpoint.enabled) {
-			sections.push({
+				rows: rowsFor('canon', (route) => {
+					const index = routeIndex(route);
+					return engine.canonVoices[index]?.preset_id ?? `Canon ${index + 1}`;
+				})
+			},
+			{
 				label: arrangement.counterpoint.phraseAware ? 'Suspension' : 'Counterpoint',
-				rows: arrangement.counterpoint.phraseAware
-					? [
-							{ route: 'counterpoint:0', label: 'Tied inner voice' },
-							{ route: 'counterpoint:1', label: 'Moving bass' }
-						]
-					: [{ route: 'counterpoint:0', label: 'Counterpoint line' }]
-			});
-		}
-		const patterns: RouteRow[] = [];
-		if (engine.companionEnabled && arrangement.patterns.lowSupport.enabled) {
-			patterns.push({ route: 'pattern_low', label: 'Low Support pattern' });
-		}
-		if (engine.companionEnabled && arrangement.patterns.counterline.enabled) {
-			patterns.push({ route: 'pattern_counter', label: 'Counterline pattern' });
-		}
-		if (patterns.length) sections.push({ label: 'Patterns', rows: patterns });
-		return sections;
+				rows: rowsFor('counterpoint', (route) => route === 'counterpoint:0'
+					? arrangement.counterpoint.phraseAware ? 'Tied inner voice' : 'Counterpoint line'
+					: 'Moving bass')
+			},
+			{
+				label: 'Patterns',
+				rows: rowsFor('patterns', (route) => route === 'pattern_low'
+					? 'Low Support pattern'
+					: 'Counterline pattern')
+			}
+		].filter(({ rows }) => rows.length > 0);
 	});
 
 	let outputOptions = $derived([
@@ -109,8 +111,18 @@
 			: SYNTH_VALUE;
 	}
 
-	function routeIsActive(route: VoiceRouteId): boolean {
+	function routeHasDestination(route: VoiceRouteId): boolean {
 		return midi.getVoiceOutput(route).kind !== 'off';
+	}
+
+	function routeStatus(row: RouteRow): string {
+		if (!row.active) return 'Part inactive; route assignment is preserved';
+		return routeHasDestination(row.route) ? 'Part active and routed' : 'Part active; destination is Off';
+	}
+
+	function routeSymbol(row: RouteRow): string {
+		if (!row.active) return '◇';
+		return routeHasDestination(row.route) ? '●' : '○';
 	}
 </script>
 
@@ -135,15 +147,12 @@
 				{#each routeSections as section (section.label)}
 					<div class="route-group font-code">{section.label}</div>
 					{#each section.rows as row (row.route)}
-						<div class="output-slot" class:slot-off={!routeIsActive(row.route)}>
-							<span
-								class="slot-status"
-								aria-hidden="true"
-								title={routeIsActive(row.route) ? 'Will produce output' : 'Silent'}
-							>
-								{routeIsActive(row.route) ? '●' : '○'}
+						<div class="output-slot" class:slot-off={!routeHasDestination(row.route)} class:part-inactive={!row.active}>
+							<span class="slot-status" aria-label={routeStatus(row)} title={routeStatus(row)}>
+								{routeSymbol(row)}
 							</span>
 							<span class="slot-label font-ui">{row.label}</span>
+							<span class="part-state font-code" class:inactive={!row.active}>{row.active ? 'Active' : 'Inactive'}</span>
 							<PixelSelect
 								options={outputOptions}
 								value={selectedOutput(row.route)}
@@ -235,23 +244,30 @@
 		color: var(--color-accent-cyan);
 		text-shadow: 0 0 4px var(--color-accent-cyan);
 	}
-	.output-slot.slot-off .slot-status {
+	.output-slot.slot-off .slot-status,
+	.output-slot.part-inactive .slot-status {
 		color: var(--color-text-dim);
 		text-shadow: none;
 	}
-	.output-slot.slot-off {
-		opacity: 0.55;
-	}
-	.output-slot.slot-off .slot-label {
-		color: var(--color-text-dim);
-	}
+	.output-slot.slot-off { opacity: 0.55; }
+	.output-slot.slot-off .slot-label,
+	.output-slot.part-inactive .slot-label { color: var(--color-text-dim); }
 
 	.slot-label {
+		min-width: 96px;
 		color: var(--color-text-secondary);
 		font-size: var(--font-size-xs);
 		white-space: nowrap;
-		min-width: 96px;
 	}
+
+	.part-state {
+		min-width: 38px;
+		color: var(--color-text-secondary);
+		font-size: 7px;
+		letter-spacing: .06em;
+		text-transform: uppercase;
+	}
+	.part-state.inactive { color: var(--color-text-dim); }
 
 	.surface-unavailable {
 		padding: 16px 12px;

--- a/ui/src/lib/components/PluginRoutingPanel.svelte
+++ b/ui/src/lib/components/PluginRoutingPanel.svelte
@@ -2,8 +2,8 @@
 	import { onMount } from 'svelte';
 	import { adapter } from '$lib/adapter';
 	import type { PluginInputMode, PluginMidiOutputMode } from '$lib/adapter/types';
+	import { synth } from '$lib/stores/synth.svelte';
 	import PixelSelect from './PixelSelect.svelte';
-	import Knob from './Knob.svelte';
 	import ToneSourcePanel from './ToneSourcePanel.svelte';
 
 	const inputOptions = [
@@ -17,20 +17,14 @@
 
 	let inputMode = $state<PluginInputMode>('midi');
 	let outputMode = $state<PluginMidiOutputMode>('full');
-	let synthEnabled = $state(true);
-	let synthGain = $state(0.25);
 
 	async function refresh() {
-		const [nextInputMode, nextOutputMode, nextSynthEnabled, synthState] = await Promise.all([
+		const [nextInputMode, nextOutputMode] = await Promise.all([
 			adapter.getPluginInputMode(),
-			adapter.getPluginMidiOutputMode(),
-			adapter.getPluginSynthEnabled(),
-			adapter.getSynthState()
+			adapter.getPluginMidiOutputMode()
 		]);
 		inputMode = nextInputMode;
 		outputMode = nextOutputMode;
-		synthEnabled = nextSynthEnabled;
-		synthGain = synthState.masterGain;
 	}
 
 	onMount(() => {
@@ -47,16 +41,6 @@
 		outputMode = value === 'pass_through' ? 'pass_through' : 'full';
 		await adapter.setPluginMidiOutputMode(outputMode);
 	}
-
-	async function toggleSynth() {
-		synthEnabled = !synthEnabled;
-		await adapter.setPluginSynthEnabled(synthEnabled);
-	}
-
-	async function setGain(gain: number) {
-		synthGain = gain;
-		await adapter.setSynthMasterGain(gain);
-	}
 </script>
 
 <div class="plugin-routing" aria-label="DAW plugin routing">
@@ -68,22 +52,12 @@
 		<span>MIDI OUTPUT</span>
 		<PixelSelect options={outputOptions} value={outputMode} small={true} onchange={setOutput} />
 	</div>
-	<button type="button" class:enabled={synthEnabled} onclick={toggleSynth}>
-		INTERNAL MONITOR {synthEnabled ? 'ON' : 'OFF'}
-	</button>
-	<Knob
-		label="Sine gain"
-		help="Level of the built-in fixed-sine monitor."
-		value={synthGain}
-		min={0}
-		max={1}
-		step={0.01}
-		defaultValue={0.25}
-		size={48}
-		format={(value) => `${Math.round(value * 100)}%`}
-		onchange={setGain}
-	/>
-	<p><strong>FL Studio:</strong> set Contrapunk's wrapper <strong>Output port</strong> and the destination synth's wrapper <strong>Input port</strong> to the same number. Turn Internal Monitor off when listening through Serum. If wrapper port forwarding is unavailable, place both plug-ins in Patcher and connect Contrapunk's MIDI output to the synth.</p>
+	<div class="monitor-status" aria-label={`Internal monitor ${synth.enabled ? `on at ${Math.round(synth.masterGain * 100)} percent` : 'off'}; controlled in Synth`}>
+		<span>INTERNAL MONITOR</span>
+		<strong>{synth.enabled ? `On · ${Math.round(synth.masterGain * 100)}%` : 'Off'}</strong>
+		<small>Controlled in Synth</small>
+	</div>
+	<p><strong>FL Studio:</strong> set Contrapunk's wrapper <strong>Output port</strong> and the destination synth's wrapper <strong>Input port</strong> to the same number. Mute Internal Monitor in Synth when listening through Serum. If wrapper port forwarding is unavailable, place both plug-ins in Patcher and connect Contrapunk's MIDI output to the synth.</p>
 	<p>For Logic guitar input, insert <strong>Contrapunk Guitar</strong> as an Audio FX, choose <strong>Guitar audio</strong>, then select <strong>Contrapunk Guitar MIDI Out</strong> on the Analog Lab instrument track.</p>
 </div>
 <ToneSourcePanel />
@@ -91,7 +65,7 @@
 <style>
 	.plugin-routing {
 		display: grid;
-		grid-template-columns: 1fr 1fr auto auto;
+		grid-template-columns: 1fr 1fr minmax(140px, auto);
 		gap: 12px;
 		margin-bottom: 14px;
 		padding: 14px;
@@ -99,10 +73,11 @@
 		background: var(--proto-panel, var(--color-bg-panel));
 	}
 	.plugin-routing > div { display: grid; gap: 6px; }
-	.plugin-routing :global(.knob) { align-self: center; }
 	span { color: var(--proto-muted, var(--color-text-secondary)); font: 700 8px var(--font-code); letter-spacing: .12em; }
-	button { align-self: end; min-height: 32px; border: 1px solid var(--proto-line-strong, var(--color-border)); background: transparent; color: var(--proto-muted, var(--color-text-secondary)); font: 700 9px var(--font-code); }
-	button.enabled { color: var(--proto-text, var(--color-text-primary)); }
+	.monitor-status { align-content: center; padding: 6px 8px; border: 1px solid var(--proto-line-strong, var(--color-border)); }
+	.monitor-status strong, .monitor-status small { display: block; }
+	.monitor-status strong { color: var(--proto-text, var(--color-text-primary)); font: 10px var(--font-code); }
+	.monitor-status small { color: var(--proto-dim, var(--color-text-dim)); font: 8px var(--font-code); }
 	p { grid-column: 1 / -1; margin: 0; color: var(--proto-dim, var(--color-text-dim)); font: 9px/1.5 var(--font-code); }
 	strong { color: var(--proto-text, var(--color-text-primary)); }
 	@media (max-width: 760px) { .plugin-routing { grid-template-columns: 1fr; } p { grid-column: auto; } }

--- a/ui/src/lib/components/PluginRoutingPanel.svelte
+++ b/ui/src/lib/components/PluginRoutingPanel.svelte
@@ -28,7 +28,7 @@
 	}
 
 	onMount(() => {
-		void refresh();
+		void Promise.all([refresh(), synth.syncFromBackend()]);
 		return adapter.onPluginParamsUpdate(() => void refresh());
 	});
 

--- a/ui/src/lib/components/elixir/ElixirWorkspace.svelte
+++ b/ui/src/lib/components/elixir/ElixirWorkspace.svelte
@@ -53,7 +53,7 @@
 						class:enabled={synth.enabled}
 						aria-pressed={synth.enabled}
 						disabled={!ready || !available}
-						onclick={() => synth.setEnabled(!synth.enabled)}
+						onclick={() => void synth.setEnabled(!synth.enabled)}
 					>
 						{synth.enabled ? 'Enabled' : 'Bypassed'}
 					</button>
@@ -81,7 +81,7 @@
 								step="0.01"
 								value={synth.masterGain}
 								disabled={!ready || (!masterOnly && !synth.enabled)}
-								oninput={(event) => synth.setMasterGain(Number(event.currentTarget.value))}
+								oninput={(event) => void synth.setMasterGain(Number(event.currentTarget.value))}
 							/>
 						</label>
 
@@ -100,10 +100,10 @@
 												step="0.01"
 												value={synth.mixGains[index]}
 												disabled={!ready || !synth.enabled}
-												oninput={(event) => synth.setMixGain(index, Number(event.currentTarget.value))}
+												oninput={(event) => void synth.setMixGain(index, Number(event.currentTarget.value))}
 											/>
-											<button class:on={synth.muted[index]} type="button" aria-label={`Mute ${role}`} aria-pressed={synth.muted[index]} disabled={!ready || !synth.enabled} onclick={() => synth.toggleMute(index)}>{synth.muted[index] ? 'M✓' : 'M'}</button>
-											<button class:on={synth.solo === index} type="button" aria-label={`Solo ${role}`} aria-pressed={synth.solo === index} disabled={!ready || !synth.enabled} onclick={() => synth.toggleSolo(index)}>{synth.solo === index ? 'S✓' : 'S'}</button>
+											<button class:on={synth.muted[index]} type="button" aria-label={`Mute ${role}`} aria-pressed={synth.muted[index]} disabled={!ready || !synth.enabled} onclick={() => void synth.toggleMute(index)}>{synth.muted[index] ? 'M✓' : 'M'}</button>
+											<button class:on={synth.solo === index} type="button" aria-label={`Solo ${role}`} aria-pressed={synth.solo === index} disabled={!ready || !synth.enabled} onclick={() => void synth.toggleSolo(index)}>{synth.solo === index ? 'S✓' : 'S'}</button>
 										</div>
 									</div>
 								{/each}

--- a/ui/src/lib/components/elixir/ElixirWorkspace.svelte
+++ b/ui/src/lib/components/elixir/ElixirWorkspace.svelte
@@ -12,7 +12,6 @@
 	const roles = ['Input', 'Harmony', 'Canon', 'Counterpoint'];
 	let ready = $state(false);
 	let error = $state('');
-	let panicSent = $state(false);
 	let available = $derived(masterOnly || adapter.capabilities.audioFx);
 
 	onMount(() => {
@@ -26,7 +25,9 @@
 				if (!cancelled) error = cause instanceof Error ? cause.message : 'Synth unavailable';
 			}
 		})();
-		const unsubscribe = adapter.onPluginParamsUpdate(() => void synth.syncFromBackend());
+		const unsubscribe = embedded
+			? () => {}
+			: adapter.onPluginParamsUpdate(() => void synth.syncFromBackend());
 		return () => {
 			cancelled = true;
 			unsubscribe();
@@ -35,12 +36,6 @@
 
 	function formatGain(gain: number) {
 		return gain <= 0.0001 ? '−∞ dB' : `${(20 * Math.log10(gain)).toFixed(1)} dB`;
-	}
-
-	async function panic() {
-		await adapter.panicAllNotesOff();
-		panicSent = true;
-		window.setTimeout(() => (panicSent = false), 700);
 	}
 </script>
 
@@ -61,9 +56,6 @@
 						onclick={() => synth.setEnabled(!synth.enabled)}
 					>
 						{synth.enabled ? 'Enabled' : 'Bypassed'}
-					</button>
-					<button class="panic" class:confirmed={panicSent} disabled={!ready} onclick={panic}>
-						{panicSent ? 'Cleared' : 'Panic'}
 					</button>
 				</div>
 			{/if}
@@ -97,19 +89,25 @@
 							<div class="role-section">
 								<h3>Roles</h3>
 								{#each roles as role, index}
-									<label class="gain-row">
+									<div class="gain-row">
 										<span><b>{role}</b><output>{formatGain(synth.mixGains[index])}</output></span>
-										<input
-											type="range"
-											min="0"
-											max="1"
-											step="0.01"
-											value={synth.mixGains[index]}
-											disabled={!ready || !synth.enabled}
-											oninput={(event) => synth.setMixGain(index, Number(event.currentTarget.value))}
-										/>
-									</label>
+										<div class="role-controls">
+											<input
+												aria-label={`${role} level`}
+												type="range"
+												min="0"
+												max="1"
+												step="0.01"
+												value={synth.mixGains[index]}
+												disabled={!ready || !synth.enabled}
+												oninput={(event) => synth.setMixGain(index, Number(event.currentTarget.value))}
+											/>
+											<button class:on={synth.muted[index]} type="button" aria-label={`Mute ${role}`} aria-pressed={synth.muted[index]} disabled={!ready || !synth.enabled} onclick={() => synth.toggleMute(index)}>{synth.muted[index] ? 'M✓' : 'M'}</button>
+											<button class:on={synth.solo === index} type="button" aria-label={`Solo ${role}`} aria-pressed={synth.solo === index} disabled={!ready || !synth.enabled} onclick={() => synth.toggleSolo(index)}>{synth.solo === index ? 'S✓' : 'S'}</button>
+										</div>
+									</div>
 								{/each}
+								{#if synth.mixError}<p class="mix-error" role="alert">{synth.mixError}</p>{/if}
 							</div>
 						{/if}
 					</div>
@@ -162,8 +160,7 @@
 		font: 12px var(--font-ui);
 	}
 	button:hover:not(:disabled) { background: #393939; color: #eee; }
-	button.enabled { border-color: #668563; color: #b7d0b3; }
-	button.panic:hover:not(:disabled), button.confirmed { border-color: #9b6666; color: #e0aaaa; }
+	button.enabled, button.on { border-color: #668563; color: #b7d0b3; }
 	button:disabled { opacity: .45; }
 	.main-grid {
 		display: grid;
@@ -181,9 +178,12 @@
 	.gain-row span { display: flex; justify-content: space-between; gap: 12px; }
 	.gain-row b { font: 500 12px var(--font-ui); color: #bbb; }
 	.gain-row output { font: 10px var(--font-code); color: #aaa; }
-	.gain-row input { width: 100%; accent-color: #7c9eb8; }
+	.gain-row input { width: 100%; min-width: 0; accent-color: #7c9eb8; }
 	.gain-row input:disabled { opacity: .35; }
 	.gain-row.master { padding-top: 2px; }
+	.role-controls { display: grid; grid-template-columns: minmax(0, 1fr) 30px 30px; align-items: center; gap: 5px; }
+	.role-controls button { width: 30px; height: 26px; padding: 0; font: 700 10px var(--font-code); }
+	.mix-error { margin: 8px 0 0; color: #e0aaaa; font: 10px/1.4 var(--font-code); }
 	.role-section { margin-top: 10px; padding-top: 12px; border-top: 1px solid #3b3b3b; }
 	.role-section h3 { margin-bottom: 5px; color: #888; text-transform: uppercase; letter-spacing: .06em; }
 	.notice { margin: 10px; padding: 14px; border: 1px solid #484848; background: #242424; color: #aaa; font: 12px var(--font-ui); }

--- a/ui/src/lib/prototype/ArrangementMixer.svelte
+++ b/ui/src/lib/prototype/ArrangementMixer.svelte
@@ -11,9 +11,13 @@
 	import { slide } from '$lib/stores/slide.svelte';
 	import { SLIDE_PRESETS, SLIDE_ROLES } from '$lib/slide/config';
 
-	let { openSetup }: { openSetup: (section: string, focus?: string) => void } = $props();
+	let { openSetup, openSynth }: {
+		openSetup: (section: string, focus?: string) => void;
+		openSynth: () => void;
+	} = $props();
 
 	const VIRTUAL_TONE_SOURCE = 999_996;
+	const synthLabel = adapter.capabilities.pluginMidiOutputMode ? 'internal monitor' : 'built-in synth';
 	type Role = {
 		name: string;
 		shortName: string;
@@ -156,12 +160,16 @@
 		}
 	]);
 
-	async function setLevel(group: number, value: number) {
-		await arrangement.setAndPushMixLevel(group, value);
+	function mixStatus(group: number): string {
+		const level = `${Math.round((synth.mixGains[group] ?? 1) * 100)}%`;
+		if (synth.muted[group]) return `Muted · ${level}`;
+		if (synth.solo === group) return `Solo · ${level}`;
+		if (synth.solo !== null) return `Muted by solo · ${level}`;
+		return level;
 	}
 
 	onMount(() => {
-		if (!arrangement.mixLoaded) void arrangement.syncFromBackend();
+		void arrangement.syncFromBackend();
 		if (!adapter.capabilities.pluginMidiOutputMode) return;
 		const refreshInputMode = () => {
 			void adapter.getPluginInputMode().then((mode) => (pluginInputMode = mode));
@@ -210,7 +218,7 @@
 					{#each SLIDE_PRESETS as preset}<option value={preset.id}>{preset.name}</option>{/each}
 				</select>
 			</label>
-			{#if arrangement.mixError}<span class="mix-error" role="alert" title={arrangement.mixError}>MIX ERROR</span>{/if}
+			{#if synth.mixError}<span class="mix-error" role="alert" title={synth.mixError}>MIX ERROR</span>{/if}
 			<button class="arrangement-setup" type="button" title="Open arrangement setup" aria-label="Open arrangement setup" onclick={() => openSetup('harmony')}>⚙</button>
 		</header>
 
@@ -225,14 +233,13 @@
 			</div>
 			<span class="arrow" aria-hidden="true">→</span>
 			<div class="output-strip">
-				<button class="node-title" type="button" title="Output setup" onclick={() => openSetup('output', 'output-routing')}>
+				<button class="node-title" type="button" title={`Open ${synthLabel}`} onclick={openSynth}>
 					<span class="activity-dot" class:active={synth.enabled}></span>
-					<strong>Master</strong><small>Built-in sine</small>
+					<strong>{adapter.capabilities.pluginMidiOutputMode ? 'Monitor' : 'Master'}</strong><small>Elixir synth</small>
 				</button>
-				<div class="node-controls master-controls">
-					<button class:on={!synth.enabled} type="button" title="Mute built-in synth" aria-label="Mute built-in synth" aria-pressed={!synth.enabled} onclick={() => synth.setEnabled(!synth.enabled)}>M</button>
-					<label title="Built-in synth master level"><input aria-label="Master output level" type="range" min="0" max="1" step="0.01" value={synth.masterGain} oninput={(event) => synth.setMasterGain(Number(event.currentTarget.value))} /><output>{Math.round(synth.masterGain * 100)}</output></label>
-				</div>
+				<button class="synth-summary" type="button" aria-label={`Open ${synthLabel}; ${synth.enabled ? `${Math.round(synth.masterGain * 100)} percent` : 'muted'}`} onclick={openSynth}>
+					<strong>{synth.enabled ? `${Math.round(synth.masterGain * 100)}%` : 'Muted'}</strong><small>Synth mix ↗</small>
+				</button>
 				<button class="node-foot output-foot" type="button" onclick={() => openSetup('output', 'output-routing')}>OUTPUT ↗</button>
 			</div>
 		</div>
@@ -244,16 +251,9 @@
 		<span class="activity-dot" class:active={role.active}></span>
 		<strong>{role.shortName}</strong><small>{role.subtitle}</small>
 	</button>
-	<div class="node-controls">
-		<div class="mix-buttons">
-			<button class:on={arrangement.muted[role.group]} type="button" title={`Mute ${role.name}`} aria-label={`Mute ${role.name} in built-in synth`} aria-pressed={arrangement.muted[role.group]} disabled={!adapter.capabilities.roleMix} onclick={() => arrangement.toggleMute(role.group)}>M</button>
-			<button class:on={arrangement.solo === role.group} type="button" title={`Solo ${role.name}`} aria-label={`Solo ${role.name} in built-in synth`} aria-pressed={arrangement.solo === role.group} disabled={!adapter.capabilities.roleMix} onclick={() => arrangement.toggleSolo(role.group)}>S</button>
-		</div>
-		<label class="gain" title={`${role.name} built-in synth level`}>
-			<input aria-label={`${role.name} built-in synth level`} type="range" min="0" max="1" step="0.01" value={arrangement.mixLevels[role.group]} disabled={!arrangement.mixLoaded || !adapter.capabilities.roleMix} oninput={(event) => setLevel(role.group, Number(event.currentTarget.value))} />
-			<output>{Math.round((arrangement.mixLevels[role.group] ?? 1) * 100)}</output>
-		</label>
-	</div>
+	<button class="synth-summary" type="button" aria-label={`Open synth mix for ${role.name}; ${mixStatus(role.group)}`} disabled={!adapter.capabilities.roleMix} onclick={openSynth}>
+		<strong>{adapter.capabilities.roleMix ? mixStatus(role.group) : 'Unavailable'}</strong><small>Synth mix ↗</small>
+	</button>
 	<div class="node-foot">
 		<button type="button" title={`Configure ${role.name} Slide`} onclick={() => openSetup('harmony', 'slide-controls')}>↝ {role.slide}</button>
 		{#if adapter.capabilities.perVoicePortRouting || adapter.capabilities.pluginMidiOutputMode}
@@ -302,26 +302,19 @@
 	.branch-rail { position: absolute; z-index: 0; inset: 50% 0 auto; height: 1px; background: var(--proto-line-strong); }
 	.role, .output-strip { position: relative; z-index: 1; display: grid; min-width: 0; grid-template-rows: 30px minmax(29px, 1fr) 28px; border: 1px solid var(--proto-line-strong); background: var(--proto-surface); }
 	.node-title { display: grid; min-width: 0; grid-template-columns: 7px 1fr; grid-template-rows: 1fr 1fr; align-items: center; column-gap: 5px; padding: 3px 6px; border: 0; border-bottom: 1px solid var(--proto-line); background: transparent; color: var(--proto-text); text-align: left; }
-	.node-title:hover, .node-foot button:hover, .output-foot:hover { background: var(--proto-hover); }
+	.node-title:hover, .synth-summary:hover:not(:disabled), .node-foot button:hover, .output-foot:hover { background: var(--proto-hover); }
 	.node-title strong, .node-title small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 	.node-title strong { align-self: end; font-size: 9px; line-height: 1; }
 	.node-title small { grid-column: 2; align-self: start; color: var(--proto-muted); font: 7px var(--font-code); }
 	.activity-dot { grid-row: 1 / 3; width: 5px; height: 5px; border: 1px solid var(--proto-muted); border-radius: 50%; }
 	.activity-dot.active { border-color: var(--role-color, var(--proto-text)); background: var(--role-color, var(--proto-text)); box-shadow: 0 0 6px var(--role-color, var(--proto-text)); }
-	.node-controls { display: grid; min-width: 0; grid-template-columns: 38px 1fr; align-items: center; gap: 5px; padding: 3px 5px; }
-	.mix-buttons { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--proto-line); }
-	.mix-buttons button, .master-controls > button { min-width: 0; height: 28px; padding: 0; border: 0; border-right: 1px solid var(--proto-line); background: transparent; color: var(--proto-muted); font: 700 7px var(--font-code); }
-	.mix-buttons button:last-child { border-right: 0; }
-	.mix-buttons button.on, .master-controls > button.on { background: var(--proto-text); color: var(--proto-bg); }
-	.mix-buttons button:disabled { opacity: .3; cursor: not-allowed; }
-	.gain, .master-controls label { display: grid; min-width: 0; grid-template-columns: 1fr 22px; align-items: center; gap: 3px; }
-	.gain input, .master-controls input { width: 100%; min-width: 0; accent-color: var(--role-color, var(--proto-text)); }
-	.gain output, .master-controls output { color: var(--proto-text); font: 7px var(--font-code); text-align: right; }
+	.synth-summary { display: grid; min-width: 0; place-content: center; gap: 2px; padding: 3px 5px; border: 0; background: transparent; color: var(--proto-text); text-align: center; }
+	.synth-summary strong { overflow: hidden; font: 700 8px var(--font-code); text-overflow: ellipsis; white-space: nowrap; }
+	.synth-summary small { color: var(--proto-muted); font: 7px var(--font-code); }
+	.synth-summary:disabled { opacity: .45; cursor: not-allowed; }
 	.node-foot { display: grid; min-width: 0; grid-template-columns: 1fr 1fr; border-top: 1px solid var(--proto-line); }
 	.node-foot button, .node-foot .route-static, .output-foot { display: grid; min-width: 0; min-height: 28px; place-items: center; overflow: hidden; padding: 0 5px; border: 0; border-right: 1px solid var(--proto-line); background: transparent; color: var(--proto-muted); font: 7px var(--font-code); text-overflow: ellipsis; white-space: nowrap; }
 	.node-foot button:last-child, .node-foot .route-static:last-child { border-right: 0; color: var(--proto-text); }
-	.master-controls { grid-template-columns: 22px 1fr; }
-	.master-controls > button { border: 1px solid var(--proto-line); }
 	.output-foot { border-top: 1px solid var(--proto-line); border-right: 0; color: var(--proto-text); }
 	@media (max-width: 1080px) {
 		.arrangement { grid-template-columns: 225px minmax(0, 1fr); }

--- a/ui/src/lib/routing/stable-voice-routes.mjs
+++ b/ui/src/lib/routing/stable-voice-routes.mjs
@@ -1,0 +1,52 @@
+/**
+ * Return every route the current arrangement can address, including inactive ones.
+ *
+ * @param {{
+ *   voiceCount: number,
+ *   voicePosition: number,
+ *   harmonyEnabled: boolean,
+ *   companionEnabled: boolean,
+ *   canonVoiceCount: number,
+ *   canonEnabled: boolean,
+ *   counterpointEnabled: boolean,
+ *   phraseAware: boolean,
+ *   patternLowEnabled: boolean,
+ *   patternCounterEnabled: boolean
+ * }} config
+ */
+export function stableVoiceRoutes(config) {
+	const companionActive = config.companionEnabled;
+	return [
+		{ section: 'input', route: 'input', active: true },
+		...Array.from({ length: config.voiceCount }, (_, slot) => ({
+			section: 'harmony',
+			route: `harmony:${slot}`,
+			active: config.harmonyEnabled && slot !== config.voicePosition
+		})),
+		...Array.from({ length: config.canonVoiceCount }, (_, voice) => ({
+			section: 'canon',
+			route: `canon:${voice}`,
+			active: companionActive && config.canonEnabled
+		})),
+		{
+			section: 'counterpoint',
+			route: 'counterpoint:0',
+			active: companionActive && config.counterpointEnabled
+		},
+		{
+			section: 'counterpoint',
+			route: 'counterpoint:1',
+			active: companionActive && config.counterpointEnabled && config.phraseAware
+		},
+		{
+			section: 'patterns',
+			route: 'pattern_low',
+			active: companionActive && config.patternLowEnabled
+		},
+		{
+			section: 'patterns',
+			route: 'pattern_counter',
+			active: companionActive && config.patternCounterEnabled
+		}
+	];
+}

--- a/ui/src/lib/routing/stable-voice-routes.test.mjs
+++ b/ui/src/lib/routing/stable-voice-routes.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { stableVoiceRoutes } from './stable-voice-routes.mjs';
+
+const base = {
+	voiceCount: 3,
+	voicePosition: 1,
+	harmonyEnabled: false,
+	companionEnabled: false,
+	canonVoiceCount: 2,
+	canonEnabled: false,
+	counterpointEnabled: false,
+	phraseAware: false,
+	patternLowEnabled: false,
+	patternCounterEnabled: false
+};
+
+test('stable routing keeps every configured route visible while inactive', () => {
+	const rows = stableVoiceRoutes(base);
+	assert.deepEqual(rows.map(({ route }) => route), [
+		'input',
+		'harmony:0',
+		'harmony:1',
+		'harmony:2',
+		'canon:0',
+		'canon:1',
+		'counterpoint:0',
+		'counterpoint:1',
+		'pattern_low',
+		'pattern_counter'
+	]);
+	assert.deepEqual(rows.filter(({ active }) => active).map(({ route }) => route), ['input']);
+});
+
+test('stable routing marks only currently producing parts active', () => {
+	const rows = stableVoiceRoutes({
+		...base,
+		harmonyEnabled: true,
+		companionEnabled: true,
+		canonEnabled: true,
+		counterpointEnabled: true,
+		phraseAware: true,
+		patternLowEnabled: true,
+		patternCounterEnabled: true
+	});
+	assert.deepEqual(rows.filter(({ active }) => !active).map(({ route }) => route), ['harmony:1']);
+});

--- a/ui/src/lib/stores/arrangement.svelte.ts
+++ b/ui/src/lib/stores/arrangement.svelte.ts
@@ -1,6 +1,7 @@
 import { adapter } from '$lib/adapter';
 import type { CounterpointSpeciesName } from './engine.svelte';
 import { DEFAULT_EXPLICIT_INTERVAL_MAP, engine } from './engine.svelte';
+import { synth } from './synth.svelte';
 import { tone } from './tone.svelte';
 import {
 	validateArrangementConfig,
@@ -46,11 +47,6 @@ function emptyPatterns(): ArrangementPatternConfig {
 class ArrangementStore {
 	counterpoint = $state<CounterpointLaneState>({ ...DEFAULT_COUNTERPOINT });
 	patterns = $state<ArrangementPatternConfig>(emptyPatterns());
-	mixLevels = $state([1, 1, 1, 1]);
-	muted = $state([false, false, false, false]);
-	solo = $state<number | null>(null);
-	mixLoaded = $state(false);
-	mixError = $state<string | null>(null);
 	applying = $state(false);
 
 	get availableCapabilities(): ReadonlySet<ArrangementCapability> {
@@ -98,17 +94,7 @@ class ArrangementStore {
 			}
 		}
 
-		if (adapter.capabilities.roleMix) {
-			try {
-				const state = await adapter.getSynthState();
-				if (state.mixGains?.length === 4 && this.solo === null && !this.muted.some(Boolean)) {
-					this.mixLevels = state.mixGains.map((value) => clamp01(value));
-				}
-			} catch {
-				// Keep unity defaults when the synth is not ready yet.
-			}
-		}
-		this.mixLoaded = true;
+		await synth.syncFromBackend();
 	}
 
 	async setPattern(
@@ -155,70 +141,6 @@ class ArrangementStore {
 			this.counterpoint = previous;
 			throw error;
 		}
-	}
-
-	setMixLevel(group: number, value: number) {
-		if (group < 0 || group >= 4) return;
-		this.mixLevels[group] = clamp01(value);
-		this.mixLevels = [...this.mixLevels];
-	}
-
-	appliedMixLevel(group: number) {
-		if (this.muted[group]) return 0;
-		if (this.solo !== null && this.solo !== group) return 0;
-		return this.mixLevels[group] ?? 1;
-	}
-
-	async pushMixLevel(group: number, value = this.appliedMixLevel(group)) {
-		if (!adapter.capabilities.roleMix || group < 0 || group >= 4) return;
-		await adapter.setSynthMixGain(group, clamp01(value));
-	}
-
-	async setAndPushMixLevel(group: number, value: number) {
-		if (!adapter.capabilities.roleMix || group < 0 || group >= 4) return;
-		const previous = this.mixLevels[group] ?? 1;
-		this.setMixLevel(group, value);
-		try {
-			await this.pushMixLevel(group);
-			this.mixError = null;
-		} catch (error) {
-			this.setMixLevel(group, previous);
-			try { await this.pushMixLevel(group); } catch { /* Preserve the original error. */ }
-			this.mixError = `Could not change mix level: ${error}`;
-		}
-	}
-
-	async toggleMute(group: number) {
-		if (!adapter.capabilities.roleMix || group < 0 || group >= 4) return;
-		const previous = [...this.muted];
-		this.muted[group] = !this.muted[group];
-		this.muted = [...this.muted];
-		try {
-			await this.pushMixLevel(group);
-			this.mixError = null;
-		} catch (error) {
-			this.muted = previous;
-			try { await this.pushMixLevel(group); } catch { /* Preserve the original error. */ }
-			this.mixError = `Could not change mute: ${error}`;
-		}
-	}
-
-	async toggleSolo(group: number) {
-		if (!adapter.capabilities.roleMix || group < 0 || group >= 4) return;
-		const previous = this.solo;
-		this.solo = this.solo === group ? null : group;
-		try {
-			await this.pushAllMixLevels();
-			this.mixError = null;
-		} catch (error) {
-			this.solo = previous;
-			try { await this.pushAllMixLevels(); } catch { /* Preserve the original error. */ }
-			this.mixError = `Could not change solo: ${error}`;
-		}
-	}
-
-	private async pushAllMixLevels() {
-		for (let group = 0; group < 4; group++) await this.pushMixLevel(group);
 	}
 
 	async apply(config: ArrangementConfig) {
@@ -300,8 +222,8 @@ class ArrangementStore {
 
 		const mix = [config.mix.input, config.mix.harmony, config.mix.canon, config.mix.counterpoint];
 		for (let group = 0; group < mix.length; group++) {
-			this.setMixLevel(group, mix[group]);
-			await this.pushMixLevel(group);
+			const applied = await synth.setMixGain(group, mix[group]);
+			if (!applied) throw new Error(synth.mixError ?? `Could not apply mix group ${group}`);
 		}
 	}
 
@@ -362,10 +284,10 @@ class ArrangementStore {
 				}
 			},
 			mix: {
-				input: this.mixLevels[0] ?? 1,
-				harmony: this.mixLevels[1] ?? 1,
-				canon: this.mixLevels[2] ?? 1,
-				counterpoint: this.mixLevels[3] ?? 1
+				input: synth.mixGains[0] ?? 1,
+				harmony: synth.mixGains[1] ?? 1,
+				canon: synth.mixGains[2] ?? 1,
+				counterpoint: synth.mixGains[3] ?? 1
 			}
 		};
 	}
@@ -408,8 +330,5 @@ function patternFromWire(state: Record<string, unknown>): ArrangementPatternLane
 	};
 }
 
-function clamp01(value: number): number {
-	return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 1));
-}
 
 export const arrangement = new ArrangementStore();

--- a/ui/src/lib/stores/midi.svelte.ts
+++ b/ui/src/lib/stores/midi.svelte.ts
@@ -17,6 +17,7 @@ import { MAX_VOICES } from '$lib/adapter/types';
 
 const MIDI_SETTINGS_KEY = 'contrapunk-midi';
 const VOICE_OUTPUTS_KEY = 'contrapunk-voice-outputs';
+const VOICE_OUTPUT_OVERRIDE_KEY = 'contrapunk-all-voice-outputs-to-synth';
 const MIDI_PERMISSION_KEY = 'contrapunk-midi-permission';
 
 interface MidiSettings {
@@ -54,13 +55,19 @@ function readTarget(
 	return Number.isInteger(deviceIndex) ? { kind: 'midi_port', port: deviceIndex } : null;
 }
 
+function browserStorage(): Storage | null {
+	return typeof localStorage === 'undefined' ? null : localStorage;
+}
+
 function loadVoiceOutputs(
 	outputs: MidiDevice[],
 	selectedOutputs: number[],
 	voicePosition: number
 ): LoadedVoiceOutputs | null {
+	const storage = browserStorage();
+	if (!storage) return null;
 	try {
-		const raw = localStorage.getItem(VOICE_OUTPUTS_KEY);
+		const raw = storage.getItem(VOICE_OUTPUTS_KEY);
 		if (!raw) return null;
 		const parsed: unknown = JSON.parse(raw);
 		const routes: VoiceOutputMap = {};
@@ -85,12 +92,15 @@ function loadVoiceOutputs(
 			if (isVoiceRouteId(route) && target && target.kind !== 'synth') routes[route] = target;
 		}
 		return { routes, migrated: !currentVersion };
-	} catch {
+	} catch (error) {
+		console.warn('[contrapunk] Could not load saved voice outputs:', error);
 		return null;
 	}
 }
 
 function saveVoiceOutputs(targets: VoiceOutputMap, outputs: MidiDevice[]) {
+	const storage = browserStorage();
+	if (!storage) return;
 	const routes: StoredVoiceOutputs['routes'] = {};
 	for (const [route, target] of Object.entries(targets)) {
 		if (!isVoiceRouteId(route) || !target || target.kind === 'synth') continue;
@@ -102,50 +112,81 @@ function saveVoiceOutputs(targets: VoiceOutputMap, outputs: MidiDevice[]) {
 		if (device) routes[route] = { kind: 'midi_port', deviceName: device.name };
 	}
 	try {
-		localStorage.setItem(
+		storage.setItem(
 			VOICE_OUTPUTS_KEY,
 			JSON.stringify({ version: 2, routes } satisfies StoredVoiceOutputs)
 		);
-	} catch {
-		// localStorage unavailable
+	} catch (error) {
+		console.warn('[contrapunk] Could not save voice outputs:', error);
+	}
+}
+
+function loadAllVoiceOutputsToSynth(): boolean {
+	const storage = browserStorage();
+	if (!storage) return false;
+	try {
+		return storage.getItem(VOICE_OUTPUT_OVERRIDE_KEY) === 'true';
+	} catch (error) {
+		console.warn('[contrapunk] Could not load the global voice-output override:', error);
+		return false;
+	}
+}
+
+function saveAllVoiceOutputsToSynth(enabled: boolean) {
+	const storage = browserStorage();
+	if (!storage) return;
+	try {
+		storage.setItem(VOICE_OUTPUT_OVERRIDE_KEY, String(enabled));
+	} catch (error) {
+		console.warn('[contrapunk] Could not save the global voice-output override:', error);
 	}
 }
 
 function loadMidiSettings(): MidiSettings | null {
+	const storage = browserStorage();
+	if (!storage) return null;
 	try {
-		const raw = localStorage.getItem(MIDI_SETTINGS_KEY);
+		const raw = storage.getItem(MIDI_SETTINGS_KEY);
 		if (!raw) return null;
 		return JSON.parse(raw);
-	} catch {
+	} catch (error) {
+		console.warn('[contrapunk] Could not load MIDI settings:', error);
 		return null;
 	}
 }
 
 function saveMidiSettings(settings: MidiSettings) {
+	const storage = browserStorage();
+	if (!storage) return;
 	try {
-		localStorage.setItem(MIDI_SETTINGS_KEY, JSON.stringify(settings));
-	} catch {
-		// localStorage unavailable
+		storage.setItem(MIDI_SETTINGS_KEY, JSON.stringify(settings));
+	} catch (error) {
+		console.warn('[contrapunk] Could not save MIDI settings:', error);
 	}
 }
 
 function loadPermissionState(): MidiPermissionState | null {
+	const storage = browserStorage();
+	if (!storage) return null;
 	try {
-		const raw = localStorage.getItem(MIDI_PERMISSION_KEY);
+		const raw = storage.getItem(MIDI_PERMISSION_KEY);
 		if (raw === 'granted' || raw === 'denied' || raw === 'idle' || raw === 'unsupported') {
 			return raw;
 		}
 		return null;
-	} catch {
+	} catch (error) {
+		console.warn('[contrapunk] Could not load MIDI permission state:', error);
 		return null;
 	}
 }
 
 function savePermissionState(state: MidiPermissionState) {
+	const storage = browserStorage();
+	if (!storage) return;
 	try {
-		localStorage.setItem(MIDI_PERMISSION_KEY, state);
-	} catch {
-		// localStorage unavailable
+		storage.setItem(MIDI_PERMISSION_KEY, state);
+	} catch (error) {
+		console.warn('[contrapunk] Could not save MIDI permission state:', error);
 	}
 }
 
@@ -176,6 +217,7 @@ class MidiStore {
 	// -- Stable musical-part output routing --
 	// Missing entries mean Synth, so first run produces audio without setup.
 	voiceOutputs = $state<VoiceOutputMap>({});
+	allVoiceOutputsToSynth = $state(loadAllVoiceOutputsToSynth());
 
 	// -- Loading / error state --
 	isLoading = $state(false);
@@ -395,6 +437,23 @@ class MidiStore {
 		}
 	}
 
+	/** Temporarily override every route with the synth while preserving per-part choices. */
+	async setAllVoiceOutputsToSynth(enabled: boolean) {
+		if (enabled === this.allVoiceOutputsToSynth) return;
+		const previous = this.allVoiceOutputsToSynth;
+		this.allVoiceOutputsToSynth = enabled;
+		saveAllVoiceOutputsToSynth(enabled);
+		try {
+			await adapter.setAllVoiceOutputsToSynth(enabled);
+			this.error = null;
+		} catch (error) {
+			this.allVoiceOutputsToSynth = previous;
+			saveAllVoiceOutputsToSynth(previous);
+			this.error = `Failed to change global voice output: ${error}`;
+			throw error;
+		}
+	}
+
 	/** Hydrate stable routes after device-name restoration, migrating old slot-based settings. */
 	async hydrateVoiceOutputs(voicePosition: number) {
 		if (!adapter.capabilities.perVoicePortRouting) return;
@@ -414,16 +473,17 @@ class MidiStore {
 					target ? [adapter.setVoiceOutput(route as VoiceRouteId, target)] : []
 				)
 			);
-			return;
+		} else {
+			try {
+				const current = await adapter.getVoiceOutputs();
+				this.voiceOutputs = Object.fromEntries(
+					current.map(({ route, target }) => [route, target])
+				) as VoiceOutputMap;
+			} catch (error) {
+				console.warn('[contrapunk] Could not hydrate voice outputs from the adapter:', error);
+			}
 		}
-		try {
-			const current = await adapter.getVoiceOutputs();
-			this.voiceOutputs = Object.fromEntries(
-				current.map(({ route, target }) => [route, target])
-			) as VoiceOutputMap;
-		} catch {
-			// Adapter may be stubbed (browser / plugin host).
-		}
+		await adapter.setAllVoiceOutputsToSynth(this.allVoiceOutputsToSynth);
 	}
 
 	/**

--- a/ui/src/lib/stores/synth-mix.mjs
+++ b/ui/src/lib/stores/synth-mix.mjs
@@ -1,0 +1,10 @@
+/**
+ * @param {number[]} levels
+ * @param {boolean[]} muted
+ * @param {number | null} solo
+ * @param {number} role
+ */
+export function appliedMixGain(levels, muted, solo, role) {
+	if (muted[role] || (solo !== null && solo !== role)) return 0;
+	return levels[role] ?? 1;
+}

--- a/ui/src/lib/stores/synth-mix.test.mjs
+++ b/ui/src/lib/stores/synth-mix.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { appliedMixGain } from './synth-mix.mjs';
+
+test('mute and solo determine each role effective gain', () => {
+	const levels = [0.25, 0.5, 0.75, 1];
+	assert.equal(appliedMixGain(levels, [false, false, false, false], null, 1), 0.5);
+	assert.equal(appliedMixGain(levels, [false, true, false, false], null, 1), 0);
+	assert.equal(appliedMixGain(levels, [false, false, false, false], 2, 1), 0);
+	assert.equal(appliedMixGain(levels, [false, false, false, false], 2, 2), 0.75);
+});

--- a/ui/src/lib/stores/synth.svelte.ts
+++ b/ui/src/lib/stores/synth.svelte.ts
@@ -1,16 +1,22 @@
 import { adapter } from '$lib/adapter';
+import { appliedMixGain as computeAppliedMixGain } from './synth-mix.mjs';
 
 class SynthStore {
 	enabled = $state(true);
 	masterGain = $state(0.25);
 	mixGains = $state([1, 1, 1, 1]);
+	muted = $state([false, false, false, false]);
+	solo = $state<number | null>(null);
+	mixError = $state<string | null>(null);
 
 	async syncFromBackend() {
 		try {
 			const state = await adapter.getSynthState();
 			this.enabled = state.enabled;
 			this.masterGain = state.masterGain;
-			this.mixGains = state.mixGains?.slice(0, 4) ?? [1, 1, 1, 1];
+			if (state.mixGains?.length === 4 && this.solo === null && !this.muted.some(Boolean)) {
+				this.mixGains = state.mixGains.map(clamp01);
+			}
 		} catch {
 			// Backend not ready yet.
 		}
@@ -26,11 +32,70 @@ class SynthStore {
 		await adapter.setSynthMasterGain(gain);
 	}
 
-	async setMixGain(role: number, gain: number) {
-		if (role < 0 || role >= this.mixGains.length) return;
-		this.mixGains = this.mixGains.map((current, index) => (index === role ? gain : current));
-		await adapter.setSynthMixGain(role, gain);
+	appliedMixGain(role: number) {
+		return computeAppliedMixGain(this.mixGains, this.muted, this.solo, role);
 	}
+
+	async setMixGain(role: number, gain: number): Promise<boolean> {
+		if (role < 0 || role >= this.mixGains.length) return false;
+		const previous = this.mixGains[role] ?? 1;
+		this.mixGains = this.mixGains.map((current, index) =>
+			index === role ? clamp01(gain) : current
+		);
+		if (!adapter.capabilities.roleMix) return true;
+		try {
+			await this.pushMixGain(role);
+			this.mixError = null;
+			return true;
+		} catch (error) {
+			this.mixGains = this.mixGains.map((current, index) =>
+				index === role ? previous : current
+			);
+			try { await this.pushMixGain(role); } catch { /* Preserve the original error. */ }
+			this.mixError = `Could not change mix level: ${error}`;
+			return false;
+		}
+	}
+
+	async toggleMute(role: number) {
+		if (!adapter.capabilities.roleMix || role < 0 || role >= this.mixGains.length) return;
+		const previous = this.muted;
+		this.muted = this.muted.map((muted, index) => index === role ? !muted : muted);
+		try {
+			await this.pushMixGain(role);
+			this.mixError = null;
+		} catch (error) {
+			this.muted = previous;
+			try { await this.pushMixGain(role); } catch { /* Preserve the original error. */ }
+			this.mixError = `Could not change mute: ${error}`;
+		}
+	}
+
+	async toggleSolo(role: number) {
+		if (!adapter.capabilities.roleMix || role < 0 || role >= this.mixGains.length) return;
+		const previous = this.solo;
+		this.solo = this.solo === role ? null : role;
+		try {
+			await this.pushAllMixGains();
+			this.mixError = null;
+		} catch (error) {
+			this.solo = previous;
+			try { await this.pushAllMixGains(); } catch { /* Preserve the original error. */ }
+			this.mixError = `Could not change solo: ${error}`;
+		}
+	}
+
+	private async pushMixGain(role: number) {
+		await adapter.setSynthMixGain(role, clamp01(this.appliedMixGain(role)));
+	}
+
+	private async pushAllMixGains() {
+		for (let role = 0; role < this.mixGains.length; role++) await this.pushMixGain(role);
+	}
+}
+
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 1));
 }
 
 export const synth = new SynthStore();

--- a/ui/src/lib/stores/synth.svelte.ts
+++ b/ui/src/lib/stores/synth.svelte.ts
@@ -52,7 +52,7 @@ class SynthStore {
 				index === role ? previous : current
 			);
 			try { await this.pushMixGain(role); } catch { /* Preserve the original error. */ }
-			this.mixError = `Could not change mix level: ${error}`;
+			this.mixError = `Could not change mix level: ${errorMessage(error)}`;
 			return false;
 		}
 	}
@@ -67,7 +67,7 @@ class SynthStore {
 		} catch (error) {
 			this.muted = previous;
 			try { await this.pushMixGain(role); } catch { /* Preserve the original error. */ }
-			this.mixError = `Could not change mute: ${error}`;
+			this.mixError = `Could not change mute: ${errorMessage(error)}`;
 		}
 	}
 
@@ -81,7 +81,7 @@ class SynthStore {
 		} catch (error) {
 			this.solo = previous;
 			try { await this.pushAllMixGains(); } catch { /* Preserve the original error. */ }
-			this.mixError = `Could not change solo: ${error}`;
+			this.mixError = `Could not change solo: ${errorMessage(error)}`;
 		}
 	}
 
@@ -92,6 +92,10 @@ class SynthStore {
 	private async pushAllMixGains() {
 		for (let role = 0; role < this.mixGains.length; role++) await this.pushMixGain(role);
 	}
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 function clamp01(value: number): number {


### PR DESCRIPTION
# Changes

- Keep the top-level **Synth / Elixir** workspace as the single editable internal-synth mixer, per the owner clarification on #179.
- Add per-role mute and solo to Elixir alongside enable, master gain, and role levels; retain only the global Panic control.
- Replace Arrangement's duplicate mixer controls with read-only level/mute/solo summaries that open Synth.
- Remove the basic synth rack and editor from Setup → Output while retaining the effects/CLAP chain and an Elixir source summary.
- Make the plug-in Internal Monitor display read-only in Setup and synchronize host parameter updates through the shared synth store.
- Move arrangement mix apply/capture onto that shared synth state and add a focused effective-gain regression test.
- Keep every supported route row visible in Output—performed input, all configured Harmony slots, configured Canon voices, both Counterpoint voices, and both Pattern routes—and mark disabled parts as inactive without discarding their assignments.
- Add one persistent **All to Synth** override that atomically routes every part to Elixir; turning it off restores the user's unchanged per-voice destinations.

The implementation direction supersedes the issue body's original Arrangement-owned proposal; the owner decision is recorded in https://github.com/contrapunk-audio/contrapunk/issues/179#issuecomment-5217557148.

## Validation

- `node --test ui/src/lib/arrangement/*.test.mjs ui/src/lib/embed/*.test.mjs ui/src/lib/routing/*.test.mjs ui/src/lib/stores/*.test.mjs` — 23 passed
- `npm --prefix ui run check` — 0 errors; 13 pre-existing warnings in unrelated files
- `npm --prefix ui run build --ignore-scripts` — passed; pre-existing warnings only
- `cargo test -p contrapunk-tauri --bin contrapunk-tauri routing::tests` — 6 passed
- `cargo tauri dev` — desktop app compiled, initialized audio/MIDI, and remained running for manual review

## Risks

- Audible level, mute, solo, preset-switch, and DAW-automation behavior still needs manual acceptance; automated coverage verifies effective mute/solo gain selection and existing arrangement persistence contracts.
- Mute and solo remain session UI state, as before; base role levels remain part of Arrangement presets.
- Mute/solo are client-side overlays on role-gain parameters, so DAW automation of those same role gains while mute or solo is active remains a manual-risk boundary.
- Switching the global routing override safely drains currently sounding notes; audible Synth → per-voice restoration still needs manual acceptance.
- Hosted plug-in audio paths are unchanged.

Closes #179

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](CONTRIBUTING.md) included if any functionality added or changed (`node --test ...` plus `npm --prefix ui run check`)
- [x] Pre-commit hook passes (`cp scripts/pre-commit .git/hooks/pre-commit` to install)
- [x] Follows the commit message standard (`feat`/`fix`/`refactor`/`docs` prefix)
- [x] Has a kind label (`kind/bug`)
- [x] User-facing changes documented in README or relevant docs (not applicable: self-evident workspace consolidation; owner decision recorded on #179)
- [x] Release notes block below updated with any user-facing changes

# Release Notes

```release-note
The top-level Elixir Synth view is now the single internal-synth mixer. Output keeps every stable part route visible, marks inactive routes without losing assignments, and adds an All to Synth override that restores the user's per-voice destinations when disabled.
```