### PR TITLE
fix: make Spread key-safe and glitch-free

### DIFF
--- a/crates/contrapunk-harmony/src/engine.rs
+++ b/crates/contrapunk-harmony/src/engine.rs
@@ -233,10 +233,9 @@ pub struct HarmonyEngine {
     key: Key,
     mode: HarmonyMode,
     octave_mode: OctaveMode,
-    /// Continuous coefficient applied to Spread and BassTrebleSplit
-    /// displacement amounts. Range [0.0, 1.0]; default 1.0 preserves
-    /// the legacy full-octave behavior. The simple-view Spread knob
-    /// uses this for smooth audible morphs as the knob sweeps.
+    /// Knob coefficient applied to Spread and BassTrebleSplit displacement.
+    /// Range [0.0, 1.0]; output is quantized to whole octaves so spreading
+    /// never changes pitch class. Default 1.0 preserves legacy behavior.
     octave_intensity: f32,
     scale_mode: ScaleMode,
     scale: Scale,
@@ -777,9 +776,8 @@ impl HarmonyEngine {
         self.clear_active_for_reharm();
     }
 
-    /// Continuous octave-spread coefficient applied to Spread and
-    /// BassTrebleSplit modes. Range [0.0, 1.0]; 0.0 = no displacement,
-    /// 1.0 = full-octave (legacy) displacement.
+    /// Octave-spread coefficient applied to Spread and BassTrebleSplit.
+    /// Range [0.0, 1.0]; displacement is quantized to whole octaves.
     pub fn octave_intensity(&self) -> f32 {
         self.octave_intensity
     }
@@ -1107,10 +1105,9 @@ impl HarmonyEngine {
             OctaveMode::Spread => {
                 for (i, note) in notes.iter_mut().enumerate().skip(1) {
                     let midi = u8::from(*note);
-                    // Continuous: per-voice shift = i × intensity × 12.
-                    // intensity = 0 → no displacement. intensity = 1 →
-                    // full-octave per voice (legacy behavior).
-                    let shift = ((i as f32) * intensity * 12.0).round().max(0.0) as u8;
+                    // Quantize before converting octaves to semitones. Rounding
+                    // semitones directly would transpose notes out of the key.
+                    let shift = ((i as f32) * intensity).round() as u8 * 12;
                     let shifted = midi.saturating_add(shift).min(127);
                     if anchor_ok(i, shifted) {
                         if let Ok(new_note) = Note::try_from(shifted) {
@@ -1121,7 +1118,7 @@ impl HarmonyEngine {
                 }
             }
             OctaveMode::BassTrebleSplit => {
-                let shift = (intensity * 12.0).round().max(0.0) as u8;
+                let shift = intensity.round() as u8 * 12;
                 for (i, note) in notes.iter_mut().enumerate().skip(1) {
                     let midi = u8::from(*note);
                     let shifted = if midi < user_midi {
@@ -2128,6 +2125,31 @@ mod tests {
         assert_eq!(result[0], Note::C4); // Melody unchanged
         assert_eq!(result[1], Note::E5); // First harmony +1 octave
         assert_eq!(result[2], Note::G6); // Second harmony +2 octaves
+    }
+
+    #[test]
+    fn test_spread_intensity_preserves_harmony_pitch_classes() {
+        fn pitches(intensity: f32) -> Vec<u8> {
+            let mut engine = HarmonyEngine::with_voices(Key::D, HarmonyMode::DiatonicThirds, 4);
+            engine.set_scale_mode(ScaleMode::Dorian);
+            engine.set_octave_mode(OctaveMode::Spread);
+            engine.set_octave_intensity(intensity);
+            engine
+                .harmonize(Note::D4)
+                .into_iter()
+                .map(|note| u8::from(note))
+                .collect()
+        }
+
+        let tight = pitches(0.0);
+        for intensity in [0.2, 0.4, 0.6, 0.8, 1.0] {
+            let spread = pitches(intensity);
+            assert_eq!(
+                spread.iter().map(|note| note % 12).collect::<Vec<_>>(),
+                tight.iter().map(|note| note % 12).collect::<Vec<_>>()
+            );
+        }
+        assert_ne!(pitches(0.6), tight, "the knob must still widen the voicing");
     }
 
     #[test]

--- a/crates/contrapunk-harmony/src/engine.rs
+++ b/crates/contrapunk-harmony/src/engine.rs
@@ -545,17 +545,16 @@ impl HarmonyEngine {
         &self.last_port_map
     }
 
-    /// Sets the octave mode.
+    /// Sets the octave mode for subsequent NoteOns.
     ///
-    /// Octave mode transforms harmony note pitches after generation:
+    /// Already-held notes keep their original generated frame so their eventual
+    /// NoteOff remains exact and knob movement cannot retrigger a sounding note.
     /// - None: No change
     /// - Spread: Each voice is +1 octave higher than previous
     /// - BassTrebleSplit: Harmonies below melody go -1 octave, above go +1 octave
     /// - Mirror: Each harmony note is duplicated at +1 and -1 octave (tripling harmony notes)
     pub fn set_octave_mode(&mut self, octave_mode: OctaveMode) {
         self.octave_mode = octave_mode;
-        // Clear note tracking since octave transformations change output
-        self.clear_active_for_reharm();
     }
 
     /// Returns the current voice count.
@@ -776,8 +775,8 @@ impl HarmonyEngine {
         self.clear_active_for_reharm();
     }
 
-    /// Octave-spread coefficient applied to Spread and BassTrebleSplit.
-    /// Range [0.0, 1.0]; displacement is quantized to whole octaves.
+    /// Octave-spread coefficient applied to subsequent NoteOns in Spread and
+    /// BassTrebleSplit. Range [0.0, 1.0]; displacement is quantized to octaves.
     pub fn octave_intensity(&self) -> f32 {
         self.octave_intensity
     }
@@ -788,7 +787,6 @@ impl HarmonyEngine {
             return;
         }
         self.octave_intensity = clamped;
-        self.clear_active_for_reharm();
     }
 
     pub fn set_beat_phase(&mut self, phase: BeatPhase) {
@@ -2153,6 +2151,28 @@ mod tests {
     }
 
     #[test]
+    fn test_spread_changes_apply_to_next_notes_without_retriggering_held_notes() {
+        let mut engine = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 3);
+        let held = engine.harmonize_note_on(Note::C4);
+        assert_eq!(held, [Note::C4, Note::E4, Note::G4]);
+
+        engine.set_octave_intensity(0.6);
+        engine.set_octave_mode(OctaveMode::Spread);
+        assert!(engine.pending_reharm_inputs.is_empty());
+        assert_eq!(engine.harmonize_note_off(Note::C4), held);
+
+        let spread = engine.harmonize_note_on(Note::D4);
+        assert_eq!(spread, [Note::D4, Note::F5, Note::A5]);
+        engine.set_octave_mode(OctaveMode::None);
+        assert!(engine.pending_reharm_inputs.is_empty());
+        assert_eq!(engine.harmonize_note_off(Note::D4), spread);
+        assert_eq!(
+            engine.harmonize_note_on(Note::E4),
+            [Note::E4, Note::G4, Note::B4]
+        );
+    }
+
+    #[test]
     fn test_octave_mode_bass_treble_split() {
         let mut engine = HarmonyEngine::with_voices(Key::C, HarmonyMode::StrictCounterpoint, 2);
         engine.set_octave_mode(OctaveMode::BassTrebleSplit);
@@ -2272,21 +2292,6 @@ mod tests {
         // 3-voice, default voice_position=2 (bass). Arrangement indices: [2, 1, 0]
         // Port map should reflect SATB arrangement positions, not identity.
         assert_eq!(port_map, &[2, 1, 0]);
-    }
-
-    #[test]
-    fn test_octave_mode_clears_note_tracking() {
-        let mut engine = HarmonyEngine::with_voices(Key::C, HarmonyMode::DiatonicThirds, 2);
-
-        // Press a note
-        engine.harmonize_note_on(Note::C4);
-
-        // Change octave mode
-        engine.set_octave_mode(OctaveMode::Spread);
-
-        // Note-Off should not find tracked harmony (cleared on octave mode change)
-        let off_result = engine.harmonize_note_off(Note::C4);
-        assert_eq!(off_result, vec![Note::C4]);
     }
 
     // Voice leading integration tests

--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -1305,7 +1305,11 @@ fn run_tauri_router(
         let live_companion_state = companion.lock().unwrap_or_else(|e| e.into_inner()).save();
         let harmony_config_changed = {
             let live = engine.lock().unwrap_or_else(|e| e.into_inner());
-            let replay = loop_engine.lock().unwrap_or_else(|e| e.into_inner());
+            let mut replay = loop_engine.lock().unwrap_or_else(|e| e.into_inner());
+            // Spread changes are next-note parameters: keep existing loop-owned
+            // frames intact and let subsequent replay NoteOns use the new value.
+            replay.set_octave_intensity(live.octave_intensity());
+            replay.set_octave_mode(live.octave_mode());
             !replay.has_same_configuration(&live)
         };
         let companion_config_changed = live_companion_state != applied_companion_state;

--- a/src-tauri/src/commands/harmony.rs
+++ b/src-tauri/src/commands/harmony.rs
@@ -184,15 +184,14 @@ pub fn set_scale_mode(mode: String, state: State<AppState>) -> Result<(), String
     Ok(())
 }
 
-/// Sets the octave mode.
+/// Sets the octave mode for subsequently played notes. Held notes retain their
+/// original generated frame until NoteOff, so no router replay is required.
 #[tauri::command]
 pub fn set_octave_mode(mode: String, state: State<AppState>) -> Result<(), String> {
     let parsed = parse_octave_mode(&mode)?;
-    {
-        let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
-        engine.set_octave_mode(parsed);
-    }
-    raise_panic(&state);
+    let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
+    engine.set_octave_mode(parsed);
+    // No raise_panic: active frames are retained until their exact NoteOff.
     Ok(())
 }
 
@@ -345,15 +344,12 @@ pub fn set_routing_mode(mode: String, state: State<AppState>) -> Result<(), Stri
     Ok(())
 }
 
-/// Octave-spread coefficient applied to Spread / Split modes.
-/// Range [0.0, 1.0]; displacement is quantized to whole octaves.
+/// Sets octave spread for subsequently played notes. Held notes are unchanged.
 #[tauri::command]
 pub fn set_octave_intensity(amount: f32, state: State<AppState>) -> Result<(), String> {
-    {
-        let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
-        engine.set_octave_intensity(amount);
-    }
-    raise_panic(&state);
+    let mut engine = state.engine.lock().map_err(|e| e.to_string())?;
+    engine.set_octave_intensity(amount);
+    // No raise_panic: active frames are retained until their exact NoteOff.
     Ok(())
 }
 

--- a/src-tauri/src/commands/harmony.rs
+++ b/src-tauri/src/commands/harmony.rs
@@ -345,8 +345,8 @@ pub fn set_routing_mode(mode: String, state: State<AppState>) -> Result<(), Stri
     Ok(())
 }
 
-/// Continuous octave-spread coefficient applied to Spread / Split modes.
-/// Range [0.0, 1.0]; 0 = no displacement, 1 = legacy full-octave behavior.
+/// Octave-spread coefficient applied to Spread / Split modes.
+/// Range [0.0, 1.0]; displacement is quantized to whole octaves.
 #[tauri::command]
 pub fn set_octave_intensity(amount: f32, state: State<AppState>) -> Result<(), String> {
     {

--- a/ui/src/lib/adapter/types.ts
+++ b/ui/src/lib/adapter/types.ts
@@ -376,10 +376,8 @@ export interface ContrapunkAdapter {
 	/** Set the octave mode (e.g. "None", "Spread", "Mirror"). */
 	setOctaveMode(mode: string): Promise<void>;
 
-	/** Continuous octave-spread coefficient applied to Spread / Split modes.
-	 *  Range [0.0, 1.0]; 0 = no displacement, 1 = full-octave (legacy)
-	 *  displacement. Used by the Performance view's Spread knob for
-	 *  smooth audible morphs. */
+	/** Octave-spread coefficient applied to Spread / Split modes.
+	 *  Range [0.0, 1.0]; displacement is quantized to whole octaves. */
 	setOctaveIntensity(amount: number): Promise<void>;
 
 	/** Configure voice leading (enabled flag + style). */

--- a/ui/src/lib/adapter/types.ts
+++ b/ui/src/lib/adapter/types.ts
@@ -376,7 +376,7 @@ export interface ContrapunkAdapter {
 	/** Set the octave mode (e.g. "None", "Spread", "Mirror"). */
 	setOctaveMode(mode: string): Promise<void>;
 
-	/** Octave-spread coefficient applied to Spread / Split modes.
+	/** Octave-spread coefficient for subsequent notes in Spread / Split modes.
 	 *  Range [0.0, 1.0]; displacement is quantized to whole octaves. */
 	setOctaveIntensity(amount: number): Promise<void>;
 

--- a/ui/src/lib/components/ContrapunkWorkspace.svelte
+++ b/ui/src/lib/components/ContrapunkWorkspace.svelte
@@ -229,7 +229,7 @@
 				<label><span>VOICES</span><select value={engine.voiceCount} onchange={(event) => engine.setVoiceCount(Number(event.currentTarget.value))}>{#each Array.from({ length: maxVoiceCount }, (_, index) => index + 1) as count}<option value={count}>{count}</option>{/each}</select></label>
 				<label><span>YOUR REGISTER</span><select value={engine.voicePosition} onchange={(event) => engine.setVoicePosition(Number(event.currentTarget.value))}>{#each registerOptions as option}<option value={option.value}>{option.label}</option>{/each}</select></label>
 				<div class="spread-control">
-					<Knob value={spread} min={0} max={1} step={0.01} defaultValue={0} size={44} label="Spread" help="Moves generated harmony voices apart by whole octaves without changing their notes or key." format={(value) => value <= 0.01 ? 'Off' : `${Math.round(value * 100)}%`} onchange={setSpread} />
+					<Knob value={spread} min={0} max={1} step={0.01} defaultValue={0} size={44} label="Spread" help="Moves newly played harmony voices apart by whole octaves without changing their notes or key. Held notes stay unchanged." format={(value) => value <= 0.01 ? 'Off' : `${Math.round(value * 100)}%`} onchange={setSpread} />
 				</div>
 			</section>
 

--- a/ui/src/lib/components/ContrapunkWorkspace.svelte
+++ b/ui/src/lib/components/ContrapunkWorkspace.svelte
@@ -23,6 +23,7 @@
 	import ControlPanel from '$lib/components/ControlPanel.svelte';
 	import EnsemblePresetBar from '$lib/components/EnsemblePresetBar.svelte';
 	import InputPanel from '$lib/components/InputPanel.svelte';
+	import Knob from '$lib/components/Knob.svelte';
 	import OutputPanel from '$lib/components/OutputPanel.svelte';
 	import PerformanceView from '$lib/components/PerformanceView.svelte';
 	import PluginRoutingPanel from '$lib/components/PluginRoutingPanel.svelte';
@@ -65,7 +66,7 @@
 		if (midi.selectedInput === null) return 'No input';
 		return midi.inputs.find((device) => device.index === midi.selectedInput)?.name ?? 'MIDI Controller';
 	});
-	let spread = $derived(engine.octaveMode === 'None' ? 0 : engine.octaveIntensity);
+	let spread = $derived(engine.octaveMode === 'Spread' ? engine.octaveIntensity : 0);
 	let maxVoiceCount = $derived(adapter.capabilities.pluginMidiOutputMode ? 4 : 8);
 	let registerOptions = $derived(
 		Array.from({ length: engine.voiceCount }, (_, index) => ({
@@ -157,12 +158,11 @@
 
 	async function setSpread(value: number) {
 		if (value <= 0.01) {
-			await engine.setOctaveIntensity(0);
 			await engine.setOctaveMode('None');
 			return;
 		}
-		if (engine.octaveMode === 'None') await engine.setOctaveMode('Spread');
 		await engine.setOctaveIntensity(value);
+		if (engine.octaveMode !== 'Spread') await engine.setOctaveMode('Spread');
 	}
 
 	async function openSetup(section: string = 'input', focus?: string) {
@@ -228,7 +228,9 @@
 				<label><span>HARMONY</span><select value={engine.mode} onchange={(event) => engine.setMode(event.currentTarget.value as HarmonyModeName)}>{#each quickModes as mode}<option value={mode.name}>{mode.label}</option>{/each}</select></label>
 				<label><span>VOICES</span><select value={engine.voiceCount} onchange={(event) => engine.setVoiceCount(Number(event.currentTarget.value))}>{#each Array.from({ length: maxVoiceCount }, (_, index) => index + 1) as count}<option value={count}>{count}</option>{/each}</select></label>
 				<label><span>YOUR REGISTER</span><select value={engine.voicePosition} onchange={(event) => engine.setVoicePosition(Number(event.currentTarget.value))}>{#each registerOptions as option}<option value={option.value}>{option.label}</option>{/each}</select></label>
-				<label class="spread"><span>SPREAD <output>{Math.round(spread * 100)}</output></span><input type="range" min="0" max="1" step="0.01" value={spread} oninput={(event) => setSpread(Number(event.currentTarget.value))} /></label>
+				<div class="spread-control">
+					<Knob value={spread} min={0} max={1} step={0.01} defaultValue={0} size={44} label="Spread" help="Moves generated harmony voices apart by whole octaves without changing their notes or key." format={(value) => value <= 0.01 ? 'Off' : `${Math.round(value * 100)}%`} onchange={setSpread} />
+				</div>
 			</section>
 
 			<div class="live-grid">
@@ -343,13 +345,12 @@
 	.synth-body { height: calc(100vh - 52px); overflow: hidden; }
 	.synth-body > :global(*) { height: 100%; }
 	.performance-body { box-sizing: border-box; display: grid; width: min(1480px, calc(100% - 20px)); height: calc(100vh - 52px); grid-template-rows: auto minmax(0, 1fr) 146px; margin: 0 auto; gap: 8px; overflow: hidden; padding: 8px 0; }
-	.quick-controls { display: grid; grid-template-columns: .7fr 1.2fr 1.3fr .55fr .9fr 1fr; border: 1px solid var(--proto-line); background: var(--proto-panel); }
+	.quick-controls { display: grid; grid-template-columns: .7fr 1.2fr 1.3fr .55fr .9fr .6fr; border: 1px solid var(--proto-line); background: var(--proto-panel); }
 	.quick-controls label { display: grid; min-width: 0; gap: 3px; padding: 6px 10px; border-right: 1px solid var(--proto-line); }
 	.quick-controls label:last-child { border-right: 0; }
 	.quick-controls span { color: var(--proto-muted); font: 700 8px var(--font-code); letter-spacing: .1em; }
 	.quick-controls select { width: 100%; min-width: 0; border: 0; background: transparent; color: var(--proto-text); font: 600 11px var(--font-grotesk); }
-	.quick-controls .spread span { display: flex; justify-content: space-between; }
-	.quick-controls input[type='range'] { width: 100%; accent-color: var(--proto-text); }
+	.spread-control { display: flex; align-items: center; justify-content: center; padding: 3px 8px; }
 	.live-grid { min-height: 0; }
 	.live-grid > :global(*) { height: 100%; }
 	.notice { padding: 18px; border: 1px solid var(--proto-line); background: var(--proto-panel); color: var(--proto-muted); font-size: 12px; }

--- a/ui/src/lib/components/Knob.svelte
+++ b/ui/src/lib/components/Knob.svelte
@@ -121,6 +121,19 @@
 		onchange(clamp(snap(value + dir * step * mul)));
 	}
 
+	function onKeyDown(e: KeyboardEvent) {
+		if (disabled) return;
+		const increment = step;
+		let next = value;
+		if (e.key === 'ArrowUp' || e.key === 'ArrowRight') next += increment;
+		else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') next -= increment;
+		else if (e.key === 'Home') next = min;
+		else if (e.key === 'End') next = max;
+		else return;
+		e.preventDefault();
+		onchange(clamp(snap(next)));
+	}
+
 	function onDoubleClick() {
 		if (disabled) return;
 		if (defaultValue !== undefined) {
@@ -144,12 +157,14 @@
 		onpointerenter={() => (hovering = true)}
 		onpointerleave={() => (hovering = false)}
 		onwheel={onWheel}
+		onkeydown={onKeyDown}
 		ondblclick={onDoubleClick}
 		role="slider"
 		tabindex={disabled ? -1 : 0}
 		aria-valuemin={min}
 		aria-valuemax={max}
 		aria-valuenow={value}
+		aria-valuetext={displayValue(value)}
 		aria-label={label}
 		aria-disabled={disabled}
 	>

--- a/ui/src/lib/components/PerformanceView.svelte
+++ b/ui/src/lib/components/PerformanceView.svelte
@@ -157,10 +157,9 @@
 		void engine.setInterchange(true, range);
 	}
 
-	// === Spread (continuous via engine octave_intensity coefficient) ===
-	// Engine takes a continuous f32 intensity that scales per-voice
-	// octave displacement. 0 = no spread (matches OctaveMode::None);
-	// 1 = full-octave spread (matches legacy OctaveMode::Spread).
+	// === Spread (knob coefficient, quantized to whole-octave moves) ===
+	// 0 = no spread (matches OctaveMode::None); 1 = full legacy spread.
+	// Whole octaves preserve every generated note's pitch class and key.
 	// Mirror / BassTrebleSplit aren't exposed in this knob — they
 	// remain available in the Advanced view's full Octave Mode picker.
 	let spread = $state(0);

--- a/ui/src/lib/components/PerformanceView.svelte
+++ b/ui/src/lib/components/PerformanceView.svelte
@@ -167,16 +167,14 @@
 		if (s <= 0.01) return 'Tight';
 		return `Wide ${Math.round(s * 100)}%`;
 	}
-	function applySpread(s: number) {
+	async function applySpread(s: number) {
 		spread = s;
 		if (s <= 0.01) {
-			void engine.setOctaveMode('None');
-		} else {
-			// Set mode first so apply_octave_mode hits the Spread branch,
-			// then push the intensity coefficient.
-			void engine.setOctaveMode('Spread');
-			void engine.setOctaveIntensity(s);
+			await engine.setOctaveMode('None');
+			return;
 		}
+		await engine.setOctaveIntensity(s);
+		await engine.setOctaveMode('Spread');
 	}
 
 	// Auto-key handling
@@ -414,6 +412,7 @@
 					step={0.01}
 					size={72}
 					label="Spread"
+					help="Applies whole-octave spacing to newly played harmony notes; held notes stay unchanged."
 					format={spreadLabel}
 					onchange={applySpread}
 				/>

--- a/ui/src/lib/prototype/ExpressionRoll.svelte
+++ b/ui/src/lib/prototype/ExpressionRoll.svelte
@@ -231,7 +231,7 @@
 		for (const [index, note] of whiteNotes.entries()) {
 			const inScale = engine.inScaleNotes.includes(note);
 			const activeColor = activeKeyColor(note);
-			ctx.fillStyle = activeColor || (inScale ? '#e4f1ee' : '#c9c9cd');
+			ctx.fillStyle = activeColor || (inScale ? '#f4f4f4' : '#c9c9cd');
 			ctx.strokeStyle = '#57575f';
 			ctx.lineWidth = 0.75;
 			ctx.shadowColor = activeColor || 'transparent';
@@ -246,7 +246,7 @@
 			if (!isBlackKey(note)) continue;
 			const inScale = engine.inScaleNotes.includes(note);
 			const activeColor = activeKeyColor(note);
-			ctx.fillStyle = activeColor || (inScale ? '#789e96' : '#17171b');
+			ctx.fillStyle = activeColor || (inScale ? '#050505' : '#2b2b2f');
 			ctx.strokeStyle = '#08080a';
 			ctx.lineWidth = 1;
 			ctx.shadowColor = activeColor || 'transparent';

--- a/ui/src/lib/stores/engine.svelte.ts
+++ b/ui/src/lib/stores/engine.svelte.ts
@@ -1354,8 +1354,8 @@ class EngineStore {
 		}
 	}
 
-	/** Octave-spread knob coefficient. Range [0,1]. The engine quantizes
-	 *  displacement to whole octaves so spreading preserves pitch class. */
+	/** Octave-spread knob coefficient for subsequent notes. Range [0,1].
+	 *  Whole-octave displacement preserves pitch class and held notes. */
 	async setOctaveIntensity(amount: number) {
 		const clamped = Math.max(0, Math.min(1, amount));
 		this.octaveIntensity = clamped;

--- a/ui/src/lib/stores/engine.svelte.ts
+++ b/ui/src/lib/stores/engine.svelte.ts
@@ -1354,10 +1354,8 @@ class EngineStore {
 		}
 	}
 
-	/** Continuous octave-spread intensity coefficient. Range [0,1].
-	 *  Used by the Performance view's Spread knob — knob value passes
-	 *  through directly. Combined with setOctaveMode, the engine
-	 *  produces a smooth audible morph as the knob sweeps. */
+	/** Octave-spread knob coefficient. Range [0,1]. The engine quantizes
+	 *  displacement to whole octaves so spreading preserves pitch class. */
 	async setOctaveIntensity(amount: number) {
 		const clamped = Math.max(0, Math.min(1, amount));
 		this.octaveIntensity = clamped;


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

- replaces the Perform view's ambiguous Spread slider with the shared rotary knob;
- fixes partial Spread values transposing harmonies by arbitrary semitones: displacement is now quantized to whole octaves, preserving every generated note's pitch class and selected key;
- makes positive knob movement explicitly select Spread and Off select no octave spreading;
- applies Spread changes only to subsequently played live and loop notes, retaining exact held-note ownership instead of retriggering sounding notes during knob movement;
- adds keyboard controls and accessible value text to the shared knob;
- restores physical piano coloring in Expression Roll: usable white keys are white and usable black keys are black rather than blue-grey;
- adds regressions proving partial spread still widens the voicing without changing harmony pitch classes or held notes.

Validation:

- `cargo test -p contrapunk-harmony --lib` — 288 passed;
- `npm --prefix ui run check` — 0 errors, 13 existing warnings;
- `cargo check -p contrapunk-tauri --message-format=short` — passes with existing warnings;
- `cargo fmt --all -- --check`;
- `git diff --check`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](CONTRIBUTING.md) included if any functionality added or changed
- [x] Pre-commit hook passes (`cp scripts/pre-commit .git/hooks/pre-commit` to install)
- [x] Follows the commit message standard (`feat`/`fix`/`refactor`/`docs` prefix)
- [x] Has a kind label (`kind/bug`, `kind/feature`, `kind/cleanup`, `kind/docs`)
- [x] User-facing changes documented in README or relevant docs
- [x] Release notes block below updated with any user-facing changes

# Release Notes

```release-note
Fixed the Spread control so partial settings widen newly played harmony voices only by whole octaves, remain inside the selected key, and do not retrigger held notes. The Perform view now uses a keyboard-accessible rotary knob, and Expression Roll scale keys retain standard white/black piano coloring.
```