### PR TITLE
feat(dsp): add cumulative wavetable learning exercises

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5566,6 +5566,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wavetable-synthesis-exercises"
+version = "0.1.0"
+dependencies = [
+ "hound",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/elixir-preset",
     "crates/golem-core",
     "apps/golem/src-tauri",
+    "examples/wavetable-synthesis",
 ]
 resolver = "2"
 

--- a/examples/wavetable-synthesis/Cargo.toml
+++ b/examples/wavetable-synthesis/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wavetable-synthesis-exercises"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+hound = "3.5"

--- a/examples/wavetable-synthesis/README.md
+++ b/examples/wavetable-synthesis/README.md
@@ -1,0 +1,45 @@
+# Wavetable-synthesis chapter exercises
+
+Runnable Rust companions for the first two chapters of the local wavetable-synthesis workbook and the research umbrella in [issue #188](https://github.com/contrapunk-audio/contrapunk/issues/188).
+
+The crate is deliberately small: one phase accumulator, visible formulas, offline rendering, and the already-used `hound` WAV writer. It is a teaching model, not Elixir's production oscillator.
+
+## Run
+
+```bash
+cargo test -p wavetable-synthesis-exercises
+cargo run -p wavetable-synthesis-exercises --bin ch01_harmonics -- /tmp/ch01.wav
+cargo run -p wavetable-synthesis-exercises --bin ch02_gesture -- /tmp/ch02.wav
+```
+
+Listen at a fixed safe level. Each WAV is generated locally; no recording is redistributed.
+
+## Cumulative ladder
+
+### Chapter 1 — cycles, harmonics, and additive tone
+
+1. Verify `period_seconds` and `harmonic_frequency` by hand and in the tests.
+2. Trace `SineOscillator::tick`: phase advances by $2\pi f/f_s$ per sample.
+3. Change the coefficient list passed to `additive_sample` and predict the spectrum first.
+4. Render the same melody with a sine and a four-harmonic recipe.
+5. Extend the eight-note A/B ostinato without changing pitch or rhythm.
+6. Add a Nyquist test before trying higher notes or longer coefficient lists.
+
+`ch01_harmonics` uses the opening of the traditional French tune *Ah! vous dirai-je, maman*. The melody predates Mozart; his public-domain variations provide a historical score reference ([IMSLP K.265/300e](https://imslp.org/wiki/12_Variations_on_%27Ah%2C_vous_dirai-je_maman%27%2C_K.265%2F300e_(Mozart%2C_Wolfgang_Amadeus))). The binary contains a new monophonic synthesis, not a copied engraving, arrangement, or recording.
+
+### Chapter 2 — difference frequency and continuous gesture
+
+1. Use `heterodyne_components` for 300.000 and 299.560 kHz.
+2. Compare linear addition with the audible scaled multiplication at the start of `ch02_gesture`.
+3. Verify `cents_ratio(1200) == 2` and the logarithmic midpoint from 220 to 880 Hz is 440 Hz.
+4. Compare detached and gliding renderings of the same note centers.
+5. Move the accent without changing pitch; then change vibrato without changing amplitude.
+6. Explain why `SineOscillator::tick(frequency_hz, ...)` integrates a trajectory correctly while `sin(2π f(t)t)` generally does not.
+
+`ch02_gesture` uses the public-domain NEW BRITAIN pitch incipit `5-1-3-1-3-2-1-6-5-5`, with simplified durations. The Library of Congress documents the tune's 1835 pairing with *Amazing Grace* ([timeline](https://www.loc.gov/collections/amazing-grace/articles-and-essays/timeline/)); [Hymnary tune record](https://hymnary.org/tune/new_britain)). No lyrics or modern arrangement are included.
+
+## Boundaries
+
+- A 48 kHz renderer cannot represent historical radio-frequency oscillators directly; Chapter 2 labels its 1000/560 Hz multiplication as an audible scaled model.
+- Harmonics at or above Nyquist are skipped. This is not a production band-limited wavetable system.
+- Generated files stay outside Git unless a review explicitly needs a small licensed fixture.

--- a/examples/wavetable-synthesis/README.md
+++ b/examples/wavetable-synthesis/README.md
@@ -16,7 +16,7 @@ Listen at a fixed safe level. Each WAV is generated locally; no recording is red
 
 ## Cumulative ladder
 
-### Chapter 1 — cycles, harmonics, and additive tone
+### Chapter 1: cycles, harmonics, and additive tone
 
 Contributor follow-up: [issue #193](https://github.com/contrapunk-audio/contrapunk/issues/193).
 
@@ -29,7 +29,7 @@ Contributor follow-up: [issue #193](https://github.com/contrapunk-audio/contrapu
 
 `ch01_harmonics` uses the opening of the traditional French tune *Ah! vous dirai-je, maman*. The melody predates Mozart; his public-domain variations provide a historical score reference ([IMSLP K.265/300e](https://imslp.org/wiki/12_Variations_on_%27Ah%2C_vous_dirai-je_maman%27%2C_K.265%2F300e_(Mozart%2C_Wolfgang_Amadeus))). The binary contains a new monophonic synthesis, not a copied engraving, arrangement, or recording.
 
-### Chapter 2 — difference frequency and continuous gesture
+### Chapter 2: difference frequency and continuous gesture
 
 Contributor follow-up: [issue #194](https://github.com/contrapunk-audio/contrapunk/issues/194).
 

--- a/examples/wavetable-synthesis/README.md
+++ b/examples/wavetable-synthesis/README.md
@@ -18,6 +18,8 @@ Listen at a fixed safe level. Each WAV is generated locally; no recording is red
 
 ### Chapter 1 — cycles, harmonics, and additive tone
 
+Contributor follow-up: [issue #193](https://github.com/contrapunk-audio/contrapunk/issues/193).
+
 1. Verify `period_seconds` and `harmonic_frequency` by hand and in the tests.
 2. Trace `SineOscillator::tick`: phase advances by $2\pi f/f_s$ per sample.
 3. Change the coefficient list passed to `additive_sample` and predict the spectrum first.
@@ -28,6 +30,8 @@ Listen at a fixed safe level. Each WAV is generated locally; no recording is red
 `ch01_harmonics` uses the opening of the traditional French tune *Ah! vous dirai-je, maman*. The melody predates Mozart; his public-domain variations provide a historical score reference ([IMSLP K.265/300e](https://imslp.org/wiki/12_Variations_on_%27Ah%2C_vous_dirai-je_maman%27%2C_K.265%2F300e_(Mozart%2C_Wolfgang_Amadeus))). The binary contains a new monophonic synthesis, not a copied engraving, arrangement, or recording.
 
 ### Chapter 2 — difference frequency and continuous gesture
+
+Contributor follow-up: [issue #194](https://github.com/contrapunk-audio/contrapunk/issues/194).
 
 1. Use `heterodyne_components` for 300.000 and 299.560 kHz.
 2. Compare linear addition with the audible scaled multiplication at the start of `ch02_gesture`.

--- a/examples/wavetable-synthesis/README.md
+++ b/examples/wavetable-synthesis/README.md
@@ -18,8 +18,6 @@ Listen at a fixed safe level. Each WAV is generated locally; no recording is red
 
 ### Chapter 1: cycles, harmonics, and additive tone
 
-Contributor follow-up: [issue #193](https://github.com/contrapunk-audio/contrapunk/issues/193).
-
 1. Verify `period_seconds` and `harmonic_frequency` by hand and in the tests.
 2. Trace `SineOscillator::tick`: phase advances by $2\pi f/f_s$ per sample.
 3. Change the coefficient list passed to `additive_sample` and predict the spectrum first.
@@ -30,8 +28,6 @@ Contributor follow-up: [issue #193](https://github.com/contrapunk-audio/contrapu
 `ch01_harmonics` uses the opening of the traditional French tune *Ah! vous dirai-je, maman*. The melody predates Mozart; his public-domain variations provide a historical score reference ([IMSLP K.265/300e](https://imslp.org/wiki/12_Variations_on_%27Ah%2C_vous_dirai-je_maman%27%2C_K.265%2F300e_(Mozart%2C_Wolfgang_Amadeus))). The binary contains a new monophonic synthesis, not a copied engraving, arrangement, or recording.
 
 ### Chapter 2: difference frequency and continuous gesture
-
-Contributor follow-up: [issue #194](https://github.com/contrapunk-audio/contrapunk/issues/194).
 
 1. Use `heterodyne_components` for 300.000 and 299.560 kHz.
 2. Compare linear addition with the audible scaled multiplication at the start of `ch02_gesture`.

--- a/examples/wavetable-synthesis/src/bin/ch01_harmonics.rs
+++ b/examples/wavetable-synthesis/src/bin/ch01_harmonics.rs
@@ -1,0 +1,64 @@
+use std::{error::Error, path::PathBuf};
+
+use wavetable_synthesis_exercises::{append_silence, render_phrase, write_wav, Note, PhraseStyle};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let output = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("ch01-harmonic-melody.wav"));
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Opening of the traditional French melody "Ah! vous dirai-je, maman".
+    // This is a new monophonic teaching rendition, not a borrowed recording or arrangement.
+    let melody = [
+        Note::new(60, 1.0),
+        Note::new(60, 1.0),
+        Note::new(67, 1.0),
+        Note::new(67, 1.0),
+        Note::new(69, 1.0),
+        Note::new(69, 1.0),
+        Note::new(67, 2.0),
+        Note::new(65, 1.0),
+        Note::new(65, 1.0),
+        Note::new(64, 1.0),
+        Note::new(64, 1.0),
+        Note::new(62, 1.0),
+        Note::new(62, 1.0),
+        Note::new(60, 2.0),
+    ];
+
+    let mut audio = render_phrase(&melody, &[1.0], 108.0, PhraseStyle::detached(0.92));
+    append_silence(&mut audio, 0.75);
+    audio.extend(render_phrase(
+        &melody,
+        &[1.0, 0.5, 0.25, 0.125],
+        108.0,
+        PhraseStyle::detached(0.92),
+    ));
+    append_silence(&mut audio, 0.75);
+
+    // Original eight-note timbre call-and-response at one fixed pitch.
+    for index in 0..8 {
+        let recipe: &[f32] = if index % 2 == 0 {
+            &[1.0, 0.5, 0.25]
+        } else {
+            &[1.0, 0.0, 0.33, 0.0, 0.2]
+        };
+        audio.extend(render_phrase(
+            &[Note::new(57, 0.5)],
+            recipe,
+            108.0,
+            PhraseStyle::detached(0.78),
+        ));
+    }
+
+    write_wav(&output, &audio)?;
+    println!("wrote {}", output.display());
+    Ok(())
+}

--- a/examples/wavetable-synthesis/src/bin/ch02_gesture.rs
+++ b/examples/wavetable-synthesis/src/bin/ch02_gesture.rs
@@ -1,0 +1,73 @@
+use std::{error::Error, path::PathBuf};
+
+use wavetable_synthesis_exercises::{
+    append_silence, heterodyne_components, render_phrase, write_wav, Note, PhraseStyle,
+    SineOscillator, SAMPLE_RATE,
+};
+
+fn render_scaled_pair(multiply: bool) -> Vec<f32> {
+    let mut fixed = SineOscillator::new();
+    let mut variable = SineOscillator::new();
+    (0..SAMPLE_RATE)
+        .map(|_| {
+            let a = fixed.tick(1_000.0, SAMPLE_RATE as f32);
+            let b = variable.tick(560.0, SAMPLE_RATE as f32);
+            if multiply {
+                a * b
+            } else {
+                0.5 * (a + b)
+            }
+        })
+        .collect()
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let output = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("ch02-gesture-phrase.wav"));
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let (difference_hz, sum_hz) = heterodyne_components(300_000.0, 299_560.0);
+    println!("RF model: difference={difference_hz:.0} Hz, sum={sum_hz:.0} Hz");
+
+    // Linear addition retains 1000 and 560 Hz; multiplication creates 440 and 1560 Hz.
+    // Real theremin RF oscillators are above the 48 kHz teaching renderer's Nyquist limit.
+    let mut audio = render_scaled_pair(false);
+    append_silence(&mut audio, 0.4);
+    audio.extend(render_scaled_pair(true));
+    append_silence(&mut audio, 0.75);
+
+    // Pitch incipit 5-1-3-1-3-2-1-6-5-5 of the public-domain NEW BRITAIN
+    // tune. Durations are simplified for this original articulation study.
+    let melody = [
+        Note::new(67, 0.5),
+        Note::new(72, 1.5),
+        Note::new(76, 0.5),
+        Note::new(72, 0.5),
+        Note::new(76, 1.5),
+        Note::new(74, 0.5),
+        Note::new(72, 0.5),
+        Note::new(69, 1.5),
+        Note::new(67, 0.5),
+        Note::new(67, 1.0),
+    ];
+    let mut continuous = PhraseStyle::legato(0.35);
+    continuous.final_vibrato_cents = 18.0;
+    audio.extend(render_phrase(&melody, &[1.0, 0.18], 84.0, continuous));
+    append_silence(&mut audio, 0.75);
+
+    let mut articulated = PhraseStyle::detached(0.76);
+    articulated.accent_note = Some(4);
+    articulated.final_vibrato_cents = 18.0;
+    audio.extend(render_phrase(&melody, &[1.0, 0.18], 84.0, articulated));
+
+    write_wav(&output, &audio)?;
+    println!("wrote {}", output.display());
+    Ok(())
+}

--- a/examples/wavetable-synthesis/src/lib.rs
+++ b/examples/wavetable-synthesis/src/lib.rs
@@ -1,0 +1,316 @@
+//! Small cumulative DSP helpers for Chapters 1–2 of the wavetable workbook.
+//!
+//! The examples favor visible mathematics over production abstractions. They
+//! write offline WAV files; they are not an audio-callback implementation.
+
+use std::path::Path;
+
+pub const SAMPLE_RATE: u32 = 48_000;
+
+/// Equal-tempered MIDI note to frequency. Kept here so the workbook bundle is
+/// runnable on its own; production Contrapunk code uses `contrapunk_dsp::pitch`.
+pub fn midi_to_freq(note: u8) -> f32 {
+    440.0 * 2.0_f32.powf((note as f32 - 69.0) / 12.0)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Note {
+    pub midi: u8,
+    pub beats: f32,
+}
+
+impl Note {
+    pub const fn new(midi: u8, beats: f32) -> Self {
+        Self { midi, beats }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Connection {
+    Detached { gate: f32 },
+    Glide { final_portion: f32 },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PhraseStyle {
+    pub connection: Connection,
+    pub accent_note: Option<usize>,
+    pub final_vibrato_cents: f32,
+}
+
+impl PhraseStyle {
+    pub const fn detached(gate: f32) -> Self {
+        Self {
+            connection: Connection::Detached { gate },
+            accent_note: None,
+            final_vibrato_cents: 0.0,
+        }
+    }
+
+    pub const fn legato(final_portion: f32) -> Self {
+        Self {
+            connection: Connection::Glide { final_portion },
+            accent_note: None,
+            final_vibrato_cents: 0.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SineOscillator {
+    phase: f32,
+}
+
+impl SineOscillator {
+    pub const fn new() -> Self {
+        Self { phase: 0.0 }
+    }
+
+    /// Advance phase once. Passing a new frequency each sample correctly
+    /// integrates a glide or vibrato trajectory.
+    pub fn tick(&mut self, frequency_hz: f32, sample_rate: f32) -> f32 {
+        let sample = self.phase.sin();
+        self.phase = (self.phase + std::f32::consts::TAU * frequency_hz / sample_rate)
+            .rem_euclid(std::f32::consts::TAU);
+        sample
+    }
+}
+
+pub fn period_seconds(frequency_hz: f32) -> Option<f32> {
+    (frequency_hz.is_finite() && frequency_hz > 0.0).then_some(1.0 / frequency_hz)
+}
+
+pub fn harmonic_frequency(fundamental_hz: f32, harmonic: usize) -> Option<f32> {
+    (fundamental_hz.is_finite() && fundamental_hz > 0.0 && harmonic > 0)
+        .then_some(fundamental_hz * harmonic as f32)
+}
+
+pub fn heterodyne_components(a_hz: f32, b_hz: f32) -> (f32, f32) {
+    ((a_hz - b_hz).abs(), a_hz + b_hz)
+}
+
+pub fn cents_ratio(cents: f32) -> f32 {
+    2.0_f32.powf(cents / 1_200.0)
+}
+
+pub fn log_frequency_lerp(start_hz: f32, end_hz: f32, t: f32) -> f32 {
+    start_hz * (end_hz / start_hz).powf(t.clamp(0.0, 1.0))
+}
+
+/// Sum one oscillator per harmonic, skip components at or above Nyquist, and
+/// normalize coefficient energy so recipes have comparable steady-state RMS.
+pub fn additive_sample(
+    oscillators: &mut [SineOscillator],
+    amplitudes: &[f32],
+    fundamental_hz: f32,
+    sample_rate: f32,
+) -> f32 {
+    let mut sample = 0.0;
+    let mut coefficient_energy = 0.0;
+
+    for (index, (oscillator, amplitude)) in oscillators
+        .iter_mut()
+        .zip(amplitudes.iter().copied())
+        .enumerate()
+    {
+        let frequency_hz = fundamental_hz * (index + 1) as f32;
+        let component = oscillator.tick(frequency_hz, sample_rate);
+        if frequency_hz < sample_rate / 2.0 {
+            sample += amplitude * component;
+            coefficient_energy += amplitude * amplitude;
+        }
+    }
+
+    if coefficient_energy > 0.0 {
+        sample / coefficient_energy.sqrt()
+    } else {
+        0.0
+    }
+}
+
+pub fn render_phrase(notes: &[Note], amplitudes: &[f32], bpm: f32, style: PhraseStyle) -> Vec<f32> {
+    let sample_rate = SAMPLE_RATE as f32;
+    let seconds_per_beat = 60.0 / bpm;
+    let mut oscillators = vec![SineOscillator::new(); amplitudes.len()];
+    let mut output = Vec::new();
+
+    for (note_index, note) in notes.iter().enumerate() {
+        let frames = (note.beats * seconds_per_beat * sample_rate).round() as usize;
+        let current_hz = midi_to_freq(note.midi);
+        let next_hz = notes
+            .get(note_index + 1)
+            .map_or(current_hz, |next| midi_to_freq(next.midi));
+
+        for frame in 0..frames {
+            let position = frame as f32 / frames.max(1) as f32;
+            let (frequency_hz, envelope) = match style.connection {
+                Connection::Detached { gate } => {
+                    let gate = gate.clamp(0.05, 1.0);
+                    let active = (frames as f32 * gate) as usize;
+                    let fade = (sample_rate * 0.005).min(active as f32 / 2.0) as usize;
+                    let envelope = if frame >= active {
+                        0.0
+                    } else if frame < fade {
+                        frame as f32 / fade.max(1) as f32
+                    } else if frame + fade >= active {
+                        (active - frame) as f32 / fade.max(1) as f32
+                    } else {
+                        1.0
+                    };
+                    (current_hz, envelope)
+                }
+                Connection::Glide { final_portion } => {
+                    let portion = final_portion.clamp(0.01, 1.0);
+                    let glide_start = 1.0 - portion;
+                    let glide_t = ((position - glide_start) / portion).clamp(0.0, 1.0);
+                    let mut envelope = 1.0;
+                    let edge = (sample_rate * 0.005) as usize;
+                    if note_index == 0 && frame < edge {
+                        envelope *= frame as f32 / edge as f32;
+                    }
+                    if note_index + 1 == notes.len() && frame + edge >= frames {
+                        envelope *= (frames - frame) as f32 / edge as f32;
+                    }
+                    (log_frequency_lerp(current_hz, next_hz, glide_t), envelope)
+                }
+            };
+
+            let vibrato = if note_index + 1 == notes.len() && style.final_vibrato_cents != 0.0 {
+                let time = output.len() as f32 / sample_rate;
+                cents_ratio(style.final_vibrato_cents * (std::f32::consts::TAU * 5.0 * time).sin())
+            } else {
+                1.0
+            };
+            let accent = if style.accent_note == Some(note_index) {
+                1.25
+            } else {
+                1.0
+            };
+            output.push(
+                envelope
+                    * accent
+                    * additive_sample(
+                        &mut oscillators,
+                        amplitudes,
+                        frequency_hz * vibrato,
+                        sample_rate,
+                    ),
+            );
+        }
+    }
+
+    output
+}
+
+pub fn append_silence(samples: &mut Vec<f32>, seconds: f32) {
+    samples.resize(
+        samples.len() + (seconds * SAMPLE_RATE as f32).round() as usize,
+        0.0,
+    );
+}
+
+pub fn write_wav(path: impl AsRef<Path>, samples: &[f32]) -> Result<(), hound::Error> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: SAMPLE_RATE,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)?;
+    for sample in samples {
+        writer.write_sample(((sample * 0.25).clamp(-1.0, 1.0) * i16::MAX as f32) as i16)?;
+    }
+    writer.finalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chapter_one_math_is_executable() {
+        assert_eq!(midi_to_freq(69), 440.0);
+        assert_eq!(period_seconds(250.0), Some(0.004));
+        assert_eq!(harmonic_frequency(110.0, 5), Some(550.0));
+        assert_eq!(harmonic_frequency(110.0, 0), None);
+    }
+
+    #[test]
+    fn oscillator_stays_bounded_during_retuning() {
+        let mut oscillator = SineOscillator::new();
+        for frequency_hz in 220..880 {
+            assert!(
+                oscillator
+                    .tick(frequency_hz as f32, SAMPLE_RATE as f32)
+                    .abs()
+                    <= 1.0
+            );
+        }
+    }
+
+    #[test]
+    fn nyquist_components_are_silent_and_recipes_are_rms_matched() {
+        let mut nyquist_oscillators = [SineOscillator::new(); 2];
+        for _ in 0..128 {
+            assert_eq!(
+                additive_sample(
+                    &mut nyquist_oscillators,
+                    &[0.0, 1.0],
+                    12_000.0,
+                    SAMPLE_RATE as f32,
+                ),
+                0.0
+            );
+        }
+
+        fn recipe_rms(amplitudes: &[f32]) -> f32 {
+            let mut oscillators = vec![SineOscillator::new(); amplitudes.len()];
+            let square_sum: f32 = (0..SAMPLE_RATE)
+                .map(|_| {
+                    additive_sample(&mut oscillators, amplitudes, 220.0, SAMPLE_RATE as f32).powi(2)
+                })
+                .sum();
+            (square_sum / SAMPLE_RATE as f32).sqrt()
+        }
+
+        assert!((recipe_rms(&[1.0]) - recipe_rms(&[1.0, 0.5, 0.25, 0.125])).abs() < 1.0e-4);
+    }
+
+    #[test]
+    fn wav_writer_preserves_accent_headroom_and_limits_extremes(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let path = std::env::temp_dir().join(format!(
+            "wavetable-synthesis-exercises-{}.wav",
+            std::process::id()
+        ));
+        write_wav(&path, &[1.25, -1.25, 4.0])?;
+        let samples: Vec<i16> = hound::WavReader::open(&path)?
+            .into_samples::<i16>()
+            .collect::<Result<_, _>>()?;
+        std::fs::remove_file(path)?;
+
+        let accented = (1.25 * 0.25 * i16::MAX as f32) as i16;
+        assert_eq!(samples, vec![accented, -accented, i16::MAX]);
+        Ok(())
+    }
+
+    #[test]
+    fn chapter_two_math_is_executable() {
+        assert_eq!(
+            heterodyne_components(260_000.0, 259_560.0),
+            (440.0, 519_560.0)
+        );
+        assert!((cents_ratio(1_200.0) - 2.0).abs() < 1.0e-6);
+        assert!((log_frequency_lerp(220.0, 880.0, 0.5) - 440.0).abs() < 1.0e-3);
+    }
+
+    #[test]
+    fn phrase_styles_keep_duration_but_change_samples() {
+        let notes = [Note::new(69, 1.0), Note::new(72, 1.0)];
+        let detached = render_phrase(&notes, &[1.0], 120.0, PhraseStyle::detached(0.8));
+        let legato = render_phrase(&notes, &[1.0], 120.0, PhraseStyle::legato(0.25));
+        assert_eq!(detached.len(), SAMPLE_RATE as usize);
+        assert_eq!(detached.len(), legato.len());
+        assert_ne!(detached, legato);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

- add a workspace-integrated `wavetable-synthesis-exercises` Rust crate
- provide cumulative Chapter 1 harmonic/additive and Chapter 2 heterodyne/gesture renderers
- generate original WAV studies from public-domain melody material without redistributing recordings or arrangements
- cover chapter arithmetic, phase accumulation, Nyquist exclusion, RMS recipe matching, phrase behavior, and WAV headroom with focused tests
- document the exercise ladder, source/rights boundaries, and commands in `examples/wavetable-synthesis/README.md`

The larger workbook, publication assets, and PDFs remain local and Git-ignored. This PR only publishes the reusable Rust learning examples that contributors can extend alongside #188.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](CONTRIBUTING.md) included if any functionality added or changed
- [x] Pre-commit hook passes (`cp scripts/pre-commit .git/hooks/pre-commit` to install)
- [x] Follows the commit message standard (`feat`/`fix`/`refactor`/`docs` prefix)
- [x] Has a kind label (`kind/bug`, `kind/feature`, `kind/cleanup`, `kind/docs`)
- [x] User-facing changes documented in README or relevant docs
- [x] Release notes block below updated with any user-facing changes

# Release Notes

```release-note
NONE
```
