### PR TITLE
feat(dsp): add Chapter 3 studio exercises

### DIFF
--- a/examples/wavetable-synthesis/README.md
+++ b/examples/wavetable-synthesis/README.md
@@ -1,6 +1,6 @@
 # Wavetable-synthesis chapter exercises
 
-Runnable Rust companions for the first two chapters of the local wavetable-synthesis workbook and the research umbrella in [issue #188](https://github.com/contrapunk-audio/contrapunk/issues/188).
+Runnable Rust companions for the first three chapters of the local wavetable-synthesis workbook and the research umbrella in [issue #188](https://github.com/contrapunk-audio/contrapunk/issues/188).
 
 The crate is deliberately small: one phase accumulator, visible formulas, offline rendering, and the already-used `hound` WAV writer. It is a teaching model, not Elixir's production oscillator.
 
@@ -10,6 +10,7 @@ The crate is deliberately small: one phase accumulator, visible formulas, offlin
 cargo test -p wavetable-synthesis-exercises
 cargo run -p wavetable-synthesis-exercises --bin ch01_harmonics -- /tmp/ch01.wav
 cargo run -p wavetable-synthesis-exercises --bin ch02_gesture -- /tmp/ch02.wav
+cargo run -p wavetable-synthesis-exercises --bin ch03_studio -- /tmp/ch03.wav
 ```
 
 Listen at a fixed safe level. Each WAV is generated locally; no recording is redistributed.
@@ -37,6 +38,17 @@ Listen at a fixed safe level. Each WAV is generated locally; no recording is red
 6. Explain why `SineOscillator::tick(frequency_hz, ...)` integrates a trajectory correctly while `sin(2π f(t)t)` generally does not.
 
 `ch02_gesture` uses the public-domain NEW BRITAIN pitch incipit `5-1-3-1-3-2-1-6-5-5`, with simplified durations. The Library of Congress documents the tune's 1835 pairing with *Amazing Grace* ([timeline](https://www.loc.gov/collections/amazing-grace/articles-and-essays/timeline/)); [Hymnary tune record](https://hymnary.org/tune/new_britain)). No lyrics or modern arrangement are included.
+
+### Chapter 3: tape operations and stored control
+
+1. Verify that changing playback rate couples duration and pitch.
+2. Reverse and splice clips while predicting the exact frame count.
+3. Draw the attack and release envelope before applying it.
+4. Verify the tiny FIR from its impulse response.
+5. Multiply a 440 Hz source by 110 Hz and check the 330/550 Hz components.
+6. Read `data/ch03-paper-roll.csv`, then compare its integer event lanes with the rendered study.
+
+The paper-roll study is project-authored and deterministic. It is a teaching surrogate, not a recording of a historical studio or RCA machine.
 
 ## Boundaries
 

--- a/examples/wavetable-synthesis/data/ch03-paper-roll.csv
+++ b/examples/wavetable-synthesis/data/ch03-paper-roll.csv
@@ -1,0 +1,6 @@
+start_frames,duration_frames,frequency_hz,level,attack_frames,release_frames,filter,modulation_hz
+0,24000,220,0.70,480,1440,dark,0
+24000,12000,330,0.55,240,960,bright,0
+36000,24000,247,0.75,480,1440,dark,73
+60000,12000,440,0.50,240,960,bright,0
+72000,36000,294,0.72,480,1920,dark,91

--- a/examples/wavetable-synthesis/src/bin/ch03_studio.rs
+++ b/examples/wavetable-synthesis/src/bin/ch03_studio.rs
@@ -1,0 +1,115 @@
+use std::{error::Error, path::PathBuf};
+
+use wavetable_synthesis_exercises::{
+    append_silence, apply_envelope, fir_filter, ring_modulate, splice_crossfade, write_wav,
+    SineOscillator, SAMPLE_RATE,
+};
+
+#[derive(Debug)]
+struct Event {
+    start: usize,
+    duration: usize,
+    frequency_hz: f32,
+    level: f32,
+    attack: usize,
+    release: usize,
+    bright: bool,
+    modulation_hz: f32,
+}
+
+fn parse_events(source: &str) -> Result<Vec<Event>, Box<dyn Error>> {
+    source
+        .lines()
+        .skip(1)
+        .map(|line| {
+            let columns: Vec<_> = line.split(',').collect();
+            if columns.len() != 8 {
+                return Err(format!("invalid event: {line}").into());
+            }
+            Ok(Event {
+                start: columns[0].parse()?,
+                duration: columns[1].parse()?,
+                frequency_hz: columns[2].parse()?,
+                level: columns[3].parse()?,
+                attack: columns[4].parse()?,
+                release: columns[5].parse()?,
+                bright: columns[6] == "bright",
+                modulation_hz: columns[7].parse()?,
+            })
+        })
+        .collect()
+}
+
+fn render(events: &[Event]) -> Vec<f32> {
+    let frames = events
+        .iter()
+        .map(|event| event.start + event.duration)
+        .max()
+        .unwrap_or(0);
+    let mut output = vec![0.0; frames];
+    for event in events {
+        let mut oscillator = SineOscillator::new();
+        let mut clip: Vec<f32> = (0..event.duration)
+            .map(|_| event.level * oscillator.tick(event.frequency_hz, SAMPLE_RATE as f32))
+            .collect();
+        apply_envelope(&mut clip, event.attack, event.release);
+        if event.modulation_hz > 0.0 {
+            ring_modulate(&mut clip, event.modulation_hz);
+        }
+        let coefficients: &[f32] = if event.bright {
+            &[0.75, 0.25]
+        } else {
+            &[0.25, 0.5, 0.25]
+        };
+        for (target, sample) in output[event.start..]
+            .iter_mut()
+            .zip(fir_filter(&clip, coefficients))
+        {
+            *target += sample;
+        }
+    }
+    output
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let output_path = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("ch03-paper-roll-study.wav"));
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let events = parse_events(include_str!("../../data/ch03-paper-roll.csv"))?;
+    let rendered = render(&events);
+    let reversed: Vec<_> = rendered.iter().rev().copied().collect();
+    let mut study = splice_crossfade(&rendered, &reversed, 480);
+    append_silence(&mut study, 0.5);
+    let peak = study.iter().copied().map(f32::abs).fold(0.0, f32::max);
+    write_wav(&output_path, &study)?;
+    println!(
+        "events={}, frames={}, peak={peak:.6}",
+        events.len(),
+        study.len()
+    );
+    println!("wrote {}", output_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_roll_has_integer_schedule_and_bounded_output() {
+        let events = parse_events(include_str!("../../data/ch03-paper-roll.csv")).unwrap();
+        let output = render(&events);
+        assert_eq!(events.len(), 5);
+        assert_eq!(output.len(), 108_000);
+        assert!(output
+            .iter()
+            .all(|sample| sample.is_finite() && sample.abs() < 1.0));
+    }
+}

--- a/examples/wavetable-synthesis/src/lib.rs
+++ b/examples/wavetable-synthesis/src/lib.rs
@@ -1,4 +1,4 @@
-//! Small cumulative DSP helpers for Chapters 1–2 of the wavetable workbook.
+//! Small cumulative DSP helpers for Chapters 1–3 of the wavetable workbook.
 //!
 //! The examples favor visible mathematics over production abstractions. They
 //! write offline WAV files; they are not an audio-callback implementation.
@@ -202,6 +202,77 @@ pub fn render_phrase(notes: &[Note], amplitudes: &[f32], bpm: f32, style: Phrase
     output
 }
 
+/// Change playback rate with linear interpolation. Like tape speed, this
+/// couples pitch and duration; it is not independent time stretching.
+pub fn resample_linear(samples: &[f32], rate: f32) -> Option<Vec<f32>> {
+    if samples.is_empty() || !rate.is_finite() || rate <= 0.0 {
+        return None;
+    }
+    let length = ((samples.len() - 1) as f32 / rate).floor() as usize + 1;
+    Some(
+        (0..length)
+            .map(|index| {
+                let position = index as f32 * rate;
+                let left = position.floor() as usize;
+                let right = (left + 1).min(samples.len() - 1);
+                let fraction = position - left as f32;
+                samples[left] + fraction * (samples[right] - samples[left])
+            })
+            .collect(),
+    )
+}
+
+pub fn apply_envelope(samples: &mut [f32], attack_frames: usize, release_frames: usize) {
+    let length = samples.len();
+    for (index, sample) in samples.iter_mut().enumerate() {
+        let attack = if attack_frames == 0 {
+            1.0
+        } else {
+            index as f32 / attack_frames as f32
+        };
+        let release = if release_frames == 0 {
+            1.0
+        } else {
+            (length - 1 - index) as f32 / release_frames as f32
+        };
+        *sample *= attack.min(release).clamp(0.0, 1.0);
+    }
+}
+
+/// Join two clips with complementary linear gains across the overlap.
+pub fn splice_crossfade(left: &[f32], right: &[f32], overlap: usize) -> Vec<f32> {
+    let overlap = overlap.min(left.len()).min(right.len());
+    let mut output = left[..left.len() - overlap].to_vec();
+    for index in 0..overlap {
+        let right_gain = (index + 1) as f32 / (overlap + 1) as f32;
+        output.push(
+            left[left.len() - overlap + index] * (1.0 - right_gain) + right[index] * right_gain,
+        );
+    }
+    output.extend_from_slice(&right[overlap..]);
+    output
+}
+
+pub fn fir_filter(samples: &[f32], coefficients: &[f32]) -> Vec<f32> {
+    (0..samples.len())
+        .map(|index| {
+            coefficients
+                .iter()
+                .enumerate()
+                .take(index + 1)
+                .map(|(delay, coefficient)| coefficient * samples[index - delay])
+                .sum()
+        })
+        .collect()
+}
+
+pub fn ring_modulate(samples: &mut [f32], frequency_hz: f32) {
+    let mut oscillator = SineOscillator::new();
+    for sample in samples {
+        *sample *= oscillator.tick(frequency_hz, SAMPLE_RATE as f32);
+    }
+}
+
 pub fn append_silence(samples: &mut Vec<f32>, seconds: f32) {
     samples.resize(
         samples.len() + (seconds * SAMPLE_RATE as f32).round() as usize,
@@ -302,6 +373,56 @@ mod tests {
         );
         assert!((cents_ratio(1_200.0) - 2.0).abs() < 1.0e-6);
         assert!((log_frequency_lerp(220.0, 880.0, 0.5) - 440.0).abs() < 1.0e-3);
+    }
+
+    #[test]
+    fn chapter_three_tape_operations_are_deterministic() {
+        assert!(resample_linear(&[0.0, 1.0], 0.0).is_none());
+        assert_eq!(
+            resample_linear(&[0.0, 1.0, 0.0], 0.5).unwrap(),
+            vec![0.0, 0.5, 1.0, 0.5, 0.0]
+        );
+        assert_eq!(
+            resample_linear(&[0.0, 1.0, 0.0], 2.0).unwrap(),
+            vec![0.0, 0.0]
+        );
+
+        let mut shaped = vec![1.0; 5];
+        apply_envelope(&mut shaped, 2, 2);
+        assert_eq!(shaped, vec![0.0, 0.5, 1.0, 0.5, 0.0]);
+
+        let spliced = splice_crossfade(&[0.0, 1.0, 1.0], &[0.0, 0.0, 1.0], 2);
+        assert_eq!(spliced.len(), 4);
+        assert!(spliced.iter().all(|sample| sample.abs() <= 1.0));
+        assert_eq!(
+            fir_filter(&[1.0, 0.0, 0.0], &[0.5, 0.25]),
+            vec![0.5, 0.25, 0.0]
+        );
+    }
+
+    #[test]
+    fn ring_modulation_creates_sum_and_difference_components() {
+        let length = SAMPLE_RATE as usize;
+        let mut source: Vec<f32> = (0..length)
+            .map(|frame| (std::f32::consts::TAU * 440.0 * frame as f32 / SAMPLE_RATE as f32).sin())
+            .collect();
+        ring_modulate(&mut source, 110.0);
+        let correlate = |frequency_hz: f32| {
+            source
+                .iter()
+                .enumerate()
+                .map(|(frame, sample)| {
+                    sample
+                        * (std::f32::consts::TAU * frequency_hz * frame as f32 / SAMPLE_RATE as f32)
+                            .cos()
+                })
+                .sum::<f32>()
+                .abs()
+                / length as f32
+        };
+        assert!(correlate(330.0) > 0.2);
+        assert!(correlate(550.0) > 0.2);
+        assert!(correlate(440.0) < 1.0e-3);
     }
 
     #[test]


### PR DESCRIPTION
<!-- Thank you for the PR! -->

# Changes

- add Chapter 3 offline tape-rate, envelope, splice, FIR, and ring-modulation exercises
- render a deterministic five-event paper-roll study from checked-in integer sample data
- add focused checks for rate coupling, envelope endpoints, FIR response, bounded splicing, sidebands, scheduling, and headroom

# Submitter Checklist

- [x] Has Tests included if functionality changed
- [x] Follows the commit message standard
- [x] Has a kind label
- [x] User-facing changes documented in relevant docs
- [x] Release notes updated below

# Release Notes

```release-note
Adds the cumulative Chapter 3 studio and stored-control exercises for the wavetable-synthesis textbook.
```
