### PR TITLE
feat(dsp): add Chapter 4 modular exercises

### DIFF
--- a/examples/wavetable-synthesis/README.md
+++ b/examples/wavetable-synthesis/README.md
@@ -1,6 +1,6 @@
 # Wavetable-synthesis chapter exercises
 
-Runnable Rust companions for the first three chapters of the local wavetable-synthesis workbook and the research umbrella in [issue #188](https://github.com/contrapunk-audio/contrapunk/issues/188).
+Runnable Rust companions for the first four chapters of the local wavetable-synthesis workbook and the research umbrella in [issue #188](https://github.com/contrapunk-audio/contrapunk/issues/188).
 
 The crate is deliberately small: one phase accumulator, visible formulas, offline rendering, and the already-used `hound` WAV writer. It is a teaching model, not Elixir's production oscillator.
 
@@ -11,6 +11,7 @@ cargo test -p wavetable-synthesis-exercises
 cargo run -p wavetable-synthesis-exercises --bin ch01_harmonics -- /tmp/ch01.wav
 cargo run -p wavetable-synthesis-exercises --bin ch02_gesture -- /tmp/ch02.wav
 cargo run -p wavetable-synthesis-exercises --bin ch03_studio -- /tmp/ch03.wav
+cargo run -p wavetable-synthesis-exercises --bin ch04_modular -- /tmp/ch04.wav
 ```
 
 Listen at a fixed safe level. Each WAV is generated locally; no recording is redistributed.
@@ -49,6 +50,17 @@ Listen at a fixed safe level. Each WAV is generated locally; no recording is red
 6. Read `data/ch03-paper-roll.csv`, then compare its integer event lanes with the rendered study.
 
 The paper-roll study is project-authored and deterministic. It is a teaching surrogate, not a recording of a historical studio or RCA machine.
+
+### Chapter 4: voltage control and a modular patch
+
+1. Verify that one octave of control doubles oscillator frequency.
+2. Follow the ADSR state changes, including retrigger and release from the current level.
+3. Compare the VCO before and after the one-pole teaching filter.
+4. Trace one sequence step across pitch, gate, envelope, VCF, and VCA.
+5. Find the explicit previous-sample variable that makes feedback causal and bounded.
+6. Render the 16-step study and verify its four-second length and safe peak.
+
+The Chapter 4 motif is project-authored and released with the workbook under CC0-1.0. The one-pole filter is an audible teaching VCF, not a Moog ladder emulation.
 
 ## Boundaries
 

--- a/examples/wavetable-synthesis/src/bin/ch04_modular.rs
+++ b/examples/wavetable-synthesis/src/bin/ch04_modular.rs
@@ -1,0 +1,72 @@
+use std::{error::Error, path::PathBuf};
+
+use wavetable_synthesis_exercises::{
+    midi_to_freq, write_wav, Adsr, OnePoleLowPass, SawOscillator, StepSequence, SAMPLE_RATE,
+};
+
+const MOTIF: [u8; 8] = [48, 55, 60, 63, 60, 55, 51, 55];
+
+fn render() -> Vec<f32> {
+    let sample_rate = SAMPLE_RATE as f32;
+    let step_frames = (0.25 * sample_rate) as usize;
+    let sequence = StepSequence::new(&MOTIF, step_frames, 0.8);
+    let mut oscillator = SawOscillator::new();
+    let mut envelope = Adsr::new(sample_rate, 0.005, 0.06, 0.6, 0.04);
+    let mut filter = OnePoleLowPass::new();
+    let mut output = Vec::with_capacity(step_frames * MOTIF.len() * 2);
+    let mut previous_gate = false;
+    let mut previous_output = 0.0_f32;
+
+    for frame in 0..output.capacity() {
+        let step = sequence.at(frame);
+        if step.gate != previous_gate {
+            envelope.gate(step.gate);
+            previous_gate = step.gate;
+        }
+        let env = envelope.next_sample();
+        let source = oscillator.tick(midi_to_freq(step.midi), sample_rate);
+        let filtered = filter.process(source, 600.0 + 2_400.0 * env, sample_rate);
+        let input = filtered + 0.35 * previous_output.tanh();
+        let sample = (0.35 * env * input).tanh();
+        previous_output = sample;
+        output.push(sample);
+    }
+    output
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let output_path = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("ch04-modular-study.wav"));
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let study = render();
+    let peak = study.iter().copied().map(f32::abs).fold(0.0, f32::max);
+    write_wav(&output_path, &study)?;
+    println!("steps=16, frames={}, peak={peak:.6}", study.len());
+    println!("wrote {}", output_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modular_study_has_deterministic_length_and_headroom() {
+        let output = render();
+        assert_eq!(output.len(), SAMPLE_RATE as usize * 4);
+        assert!(output
+            .iter()
+            .all(|sample| sample.is_finite() && sample.abs() <= 1.0));
+        assert!(output.iter().copied().map(f32::abs).fold(0.0, f32::max) < 0.5);
+        assert!((output[0] + 0.000_111_918_45).abs() < 1.0e-9);
+        assert!((output[48_000] - 0.000_908_873_6).abs() < 1.0e-8);
+    }
+}

--- a/examples/wavetable-synthesis/src/bin/ch04_modular.rs
+++ b/examples/wavetable-synthesis/src/bin/ch04_modular.rs
@@ -1,7 +1,8 @@
 use std::{error::Error, path::PathBuf};
 
 use wavetable_synthesis_exercises::{
-    midi_to_freq, write_wav, Adsr, OnePoleLowPass, SawOscillator, StepSequence, SAMPLE_RATE,
+    bounded_feedback, midi_to_freq, write_wav, Adsr, OnePoleLowPass, SawOscillator, StepSequence,
+    SAMPLE_RATE,
 };
 
 const MOTIF: [u8; 8] = [48, 55, 60, 63, 60, 55, 51, 55];
@@ -13,11 +14,12 @@ fn render() -> Vec<f32> {
     let mut oscillator = SawOscillator::new();
     let mut envelope = Adsr::new(sample_rate, 0.005, 0.06, 0.6, 0.04);
     let mut filter = OnePoleLowPass::new();
-    let mut output = Vec::with_capacity(step_frames * MOTIF.len() * 2);
+    let frame_count = step_frames * MOTIF.len() * 2;
+    let mut output = Vec::with_capacity(frame_count);
     let mut previous_gate = false;
     let mut previous_output = 0.0_f32;
 
-    for frame in 0..output.capacity() {
+    for frame in 0..frame_count {
         let step = sequence.at(frame);
         if step.gate != previous_gate {
             envelope.gate(step.gate);
@@ -26,7 +28,7 @@ fn render() -> Vec<f32> {
         let env = envelope.next_sample();
         let source = oscillator.tick(midi_to_freq(step.midi), sample_rate);
         let filtered = filter.process(source, 600.0 + 2_400.0 * env, sample_rate);
-        let input = filtered + 0.35 * previous_output.tanh();
+        let input = bounded_feedback(filtered, previous_output, 0.35);
         let sample = (0.35 * env * input).tanh();
         previous_output = sample;
         output.push(sample);

--- a/examples/wavetable-synthesis/src/lib.rs
+++ b/examples/wavetable-synthesis/src/lib.rs
@@ -1,4 +1,4 @@
-//! Small cumulative DSP helpers for Chapters 1–3 of the wavetable workbook.
+//! Small cumulative DSP helpers for Chapters 1–4 of the wavetable workbook.
 //!
 //! The examples favor visible mathematics over production abstractions. They
 //! write offline WAV files; they are not an audio-callback implementation.
@@ -74,6 +74,165 @@ impl SineOscillator {
             .rem_euclid(std::f32::consts::TAU);
         sample
     }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SawOscillator {
+    phase: f32,
+}
+
+impl SawOscillator {
+    pub const fn new() -> Self {
+        Self { phase: 0.0 }
+    }
+
+    pub fn tick(&mut self, frequency_hz: f32, sample_rate: f32) -> f32 {
+        let sample = 2.0 * self.phase - 1.0;
+        self.phase = (self.phase + frequency_hz.clamp(0.0, sample_rate * 0.45) / sample_rate)
+            .rem_euclid(1.0);
+        sample
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdsrStage {
+    Idle,
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Adsr {
+    sample_rate: f32,
+    attack: f32,
+    decay: f32,
+    sustain: f32,
+    release: f32,
+    stage: AdsrStage,
+    level: f32,
+    start: f32,
+    elapsed: usize,
+}
+
+impl Adsr {
+    pub fn new(sample_rate: f32, attack: f32, decay: f32, sustain: f32, release: f32) -> Self {
+        Self {
+            sample_rate,
+            attack: attack.max(0.0),
+            decay: decay.max(0.0),
+            sustain: sustain.clamp(0.0, 1.0),
+            release: release.max(0.0),
+            stage: AdsrStage::Idle,
+            level: 0.0,
+            start: 0.0,
+            elapsed: 0,
+        }
+    }
+
+    pub const fn stage(&self) -> AdsrStage {
+        self.stage
+    }
+
+    pub const fn level(&self) -> f32 {
+        self.level
+    }
+
+    pub fn gate(&mut self, on: bool) {
+        self.start = self.level;
+        self.elapsed = 0;
+        self.stage = if on {
+            AdsrStage::Attack
+        } else {
+            AdsrStage::Release
+        };
+    }
+
+    pub fn next_sample(&mut self) -> f32 {
+        loop {
+            let (target, seconds, next) = match self.stage {
+                AdsrStage::Idle => return 0.0,
+                AdsrStage::Attack => (1.0, self.attack, AdsrStage::Decay),
+                AdsrStage::Decay => (self.sustain, self.decay, AdsrStage::Sustain),
+                AdsrStage::Sustain => return self.sustain,
+                AdsrStage::Release => (0.0, self.release, AdsrStage::Idle),
+            };
+            let frames = (seconds * self.sample_rate).round() as usize;
+            if frames == 0 {
+                self.level = target;
+                self.start = target;
+                self.elapsed = 0;
+                self.stage = next;
+                continue;
+            }
+            self.elapsed += 1;
+            let t = (self.elapsed as f32 / frames as f32).clamp(0.0, 1.0);
+            self.level = self.start + (target - self.start) * t;
+            if self.elapsed >= frames {
+                self.start = target;
+                self.elapsed = 0;
+                self.stage = next;
+            }
+            return self.level;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OnePoleLowPass {
+    z1: f32,
+}
+
+impl OnePoleLowPass {
+    pub const fn new() -> Self {
+        Self { z1: 0.0 }
+    }
+
+    pub fn process(&mut self, input: f32, cutoff_hz: f32, sample_rate: f32) -> f32 {
+        let cutoff = cutoff_hz.clamp(f32::EPSILON, sample_rate * 0.45);
+        let a = (-std::f32::consts::TAU * cutoff / sample_rate).exp();
+        self.z1 = (1.0 - a) * input + a * self.z1;
+        self.z1
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SequenceStep {
+    pub midi: u8,
+    pub gate: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct StepSequence<'a> {
+    notes: &'a [u8],
+    step_frames: usize,
+    gate_fraction: f32,
+}
+
+impl<'a> StepSequence<'a> {
+    pub fn new(notes: &'a [u8], step_frames: usize, gate_fraction: f32) -> Self {
+        assert!(!notes.is_empty());
+        assert!(step_frames > 0);
+        Self {
+            notes,
+            step_frames,
+            gate_fraction: gate_fraction.clamp(0.0, 1.0),
+        }
+    }
+
+    pub fn at(&self, frame: usize) -> SequenceStep {
+        let step = (frame / self.step_frames) % self.notes.len();
+        let within = frame % self.step_frames;
+        SequenceStep {
+            midi: self.notes[step],
+            gate: within < (self.step_frames as f32 * self.gate_fraction).round() as usize,
+        }
+    }
+}
+
+pub fn bounded_feedback(input: f32, previous_output: f32, gain: f32) -> f32 {
+    input + gain.clamp(-0.999, 0.999) * previous_output.tanh()
 }
 
 pub fn period_seconds(frequency_hz: f32) -> Option<f32> {
@@ -433,5 +592,101 @@ mod tests {
         assert_eq!(detached.len(), SAMPLE_RATE as usize);
         assert_eq!(detached.len(), legato.len());
         assert_ne!(detached, legato);
+    }
+
+    #[test]
+    fn octave_voltage_doubles_frequency() {
+        let f0 = 220.0;
+        assert_eq!(f0 * 2.0_f32.powf(1.0), 440.0);
+        assert!((f0 * 2.0_f32.powf(1.0 / 12.0) - midi_to_freq(58)).abs() < 1.0e-4);
+    }
+
+    #[test]
+    fn adsr_transitions_retrigger_and_release_from_current_level() {
+        let mut envelope = Adsr::new(10.0, 0.2, 0.2, 0.5, 0.2);
+        envelope.gate(true);
+        assert_eq!(envelope.next_sample(), 0.5);
+        assert_eq!(envelope.next_sample(), 1.0);
+        assert_eq!(envelope.stage(), AdsrStage::Decay);
+        assert_eq!(envelope.next_sample(), 0.75);
+        envelope.gate(true);
+        assert!((envelope.next_sample() - 0.875).abs() < 1.0e-6);
+        envelope.gate(false);
+        let release_start = envelope.level();
+        assert!((envelope.next_sample() - release_start * 0.5).abs() < 1.0e-6);
+        assert_eq!(envelope.next_sample(), 0.0);
+        assert_eq!(envelope.stage(), AdsrStage::Idle);
+    }
+
+    #[test]
+    fn zero_length_adsr_segments_jump_to_targets() {
+        let mut envelope = Adsr::new(48_000.0, 0.0, 0.0, 0.4, 0.0);
+        envelope.gate(true);
+        assert_eq!(envelope.next_sample(), 0.4);
+        assert_eq!(envelope.stage(), AdsrStage::Sustain);
+        envelope.gate(false);
+        assert_eq!(envelope.next_sample(), 0.0);
+        assert_eq!(envelope.stage(), AdsrStage::Idle);
+    }
+
+    #[test]
+    fn one_pole_filter_converges_and_stays_finite() {
+        let mut filter = OnePoleLowPass::new();
+        let mut sample = 0.0;
+        for _ in 0..SAMPLE_RATE {
+            sample = filter.process(1.0, 900.0, SAMPLE_RATE as f32);
+            assert!(sample.is_finite());
+        }
+        assert!((sample - 1.0).abs() < 1.0e-5);
+    }
+
+    #[test]
+    fn sequence_obeys_step_and_gate_boundaries() {
+        let sequence = StepSequence::new(&[48, 55], 100, 0.8);
+        assert_eq!(
+            sequence.at(0),
+            SequenceStep {
+                midi: 48,
+                gate: true
+            }
+        );
+        assert_eq!(
+            sequence.at(79),
+            SequenceStep {
+                midi: 48,
+                gate: true
+            }
+        );
+        assert_eq!(
+            sequence.at(80),
+            SequenceStep {
+                midi: 48,
+                gate: false
+            }
+        );
+        assert_eq!(
+            sequence.at(100),
+            SequenceStep {
+                midi: 55,
+                gate: true
+            }
+        );
+        assert_eq!(
+            sequence.at(200),
+            SequenceStep {
+                midi: 48,
+                gate: true
+            }
+        );
+    }
+
+    #[test]
+    fn delayed_feedback_is_bounded_for_bounded_input() {
+        let mut previous = 0.0;
+        for frame in 0..20_000 {
+            let input = if frame == 0 { 0.5 } else { 0.0 };
+            previous = bounded_feedback(input, previous, 0.95).tanh();
+            assert!(previous.is_finite() && previous.abs() <= 1.0);
+        }
     }
 }


### PR DESCRIPTION
# Changes

Add the cumulative Chapter 4 modular-synthesis exercises:

- per-sample saw VCO frequency
- ADSR state machine with retrigger and release-from-current-level behavior
- one-pole low-pass teaching filter
- deterministic step sequence and bounded delayed feedback
- `ch04_modular` offline renderer with focused lifecycle, boundary, boundedness, length, and headroom tests

The implementation remains intentionally small and reuses the existing teaching crate. It does not add a graph framework or dependency.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Tests](CONTRIBUTING.md) included if any functionality added or changed
- [x] Pre-commit hook passes (`cp scripts/pre-commit .git/hooks/pre-commit` to install)
- [x] Follows the commit message standard (`feat`/`fix`/`refactor`/`docs` prefix)
- [x] Has a kind label (`kind/bug`, `kind/feature`, `kind/cleanup`, `kind/docs`)
- [x] User-facing changes documented in README or relevant docs
- [x] Release notes block below updated with any user-facing changes

# Release Notes

```release-note
Add runnable Chapter 4 modular-synthesis teaching exercises and an offline study renderer.
```
